### PR TITLE
Correct player leave stat recalc

### DIFF
--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -347,8 +347,8 @@ class AutoBalance_AllMapScript : public AllMapScript
                 }
             }
 
-            // mapABInfo->playerCount++; (maybe we've to found a safe solution to avoid player recount each time)
-            mapABInfo->playerCount = map->GetPlayersCountExceptGMs();
+            mapABInfo->playerCount++; //(maybe we've to found a safe solution to avoid player recount each time)
+            //mapABInfo->playerCount = map->GetPlayersCountExceptGMs();
 
             if (PlayerChangeNotify > 0)
             {
@@ -380,8 +380,8 @@ class AutoBalance_AllMapScript : public AllMapScript
 
             AutoBalanceMapInfo *mapABInfo=map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
 
-            // mapABInfo->playerCount--; (maybe we've to found a safe solution to avoid player recount each time)
-            mapABInfo->playerCount = map->GetPlayersCountExceptGMs();
+            mapABInfo->playerCount--;// (maybe we've to found a safe solution to avoid player recount each time)
+            // mapABInfo->playerCount = map->GetPlayersCountExceptGMs();
 
             // always check level, even if not conf enabled
             // because we can enable at runtime and we need this information


### PR DESCRIPTION
Currently, when OnPlayerLeaveAll is called, the player is still counted in GetPlayersCountExceptGMs so switching to a regular decrements, as it is called once per player leaving the map, allows for it to properly recalculate the stats of monsters as players leave the map. This commit also changes the instance of GetPlayersCountExceptGMs in OnPlayerEnterAll to a simple increment as it is called once per player entering the map as well.