### PR TITLE
feat(Config): Add config options "MinManaModifier", "DungeonScaleDownXP"; remove unused option "Instances"

### DIFF
--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -75,15 +75,17 @@ AutoBalance.levelUseDbValuesWhenExists = 0
 AutoBalance.LevelEndGameBoost = 1
 
 #
-#     AutoBalance.Instances
-#        Set instances to Auto chance XPlayer depending on players in it.
-#        Default:     1 (1 = ON, 0 = OFF)
+#     AutoBalance.DungeonFullGroupXP
+#        Ensure that the player always gets the same XP as if entering the dungeon with a full group
+#        Default:     0 (1 = ON, 0 = OFF)
 
-AutoBalance.Instances=1
+AutoBalance.DungeonFullGroupXP=0
+
 #
 #     AutoBalance.DungeonsOnly
 #        Only apply scaling changes to dungeons and raids
 #        Default:     1 (1 = ON, 0 = OFF)
+
 AutoBalance.DungeonsOnly=1
 
 #

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -111,6 +111,13 @@ AutoBalance.PlayerChangeNotify=1
 AutoBalance.MinHPModifier=0.01
 
 #
+#     AutoBalance.MinManaModifier
+#        Minimum Modifier setting for Mana Modification
+#        Default:     0.01
+
+AutoBalance.MinManaModifier=0.01
+
+#
 #     AutoBalance.MinDamageModifier
 #        Minimum Modifier setting for Damage Modification
 #        Default:     0.01

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -75,11 +75,15 @@ AutoBalance.levelUseDbValuesWhenExists = 0
 AutoBalance.LevelEndGameBoost = 1
 
 #
-#     AutoBalance.DungeonFullGroupXP
-#        Ensure that the player always gets the same XP as if entering the dungeon with a full group
+#     AutoBalance.DungeonScaleDownXP
+#        Decrease individual player's amount of XP gained during a dungeon to match the
+#        amount of XP gained during a full group run. Example: In a 5-man group, you
+#        earn 1/5 of the total XP per kill, but if you solo the dungeon with
+#        AutoBalance.DungeonScaleDownXP = 0, you will earn 5/5 of the total XP.
+#        With the option enabled, you will earn 1/5.
 #        Default:     0 (1 = ON, 0 = OFF)
 
-AutoBalance.DungeonFullGroupXP=0
+AutoBalance.DungeonScaleDownXP = 0
 
 #
 #     AutoBalance.DungeonsOnly

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -228,14 +228,15 @@ class AutoBalance_PlayerScript : public PlayerScript
         {
         }
 
-        void OnLogin(Player *Player)
+        void OnLogin(Player *Player) override
         {
             if (sConfigMgr->GetBoolDefault("AutoBalanceAnnounce.enable", true)) {
                 ChatHandler(Player->GetSession()).SendSysMessage("This server is running the |cff4CFF00AutoBalance |rmodule.");
             }
         }
 
-        virtual void OnLevelChanged(Player* player, uint8 /*oldlevel*/) {
+        virtual void OnLevelChanged(Player* player, uint8 /*oldlevel*/) override
+        {
             if (!enabled || !player)
                 return;
 
@@ -246,6 +247,22 @@ class AutoBalance_PlayerScript : public PlayerScript
 
             if (mapABInfo->mapLevel < player->getLevel())
                 mapABInfo->mapLevel = player->getLevel();
+        }
+
+        void OnGiveXP(Player* player, uint32& amount, Unit* victim) override
+        {
+            if (victim && sConfigMgr->GetBoolDefault("AutoBalance.DungeonFullGroupXP", 0))
+            {
+                Map* map = player->GetMap();
+
+                if (map->IsDungeon())
+                {
+                    // Ensure that the players always get the same XP, even when entering the dungeon alone
+                    uint32 maxPlayerCount = ((InstanceMap*)sMapMgr->FindMap(map->GetId(), map->GetInstanceId()))->GetMaxPlayers();
+                    uint32 currentPlayerCount = map->GetPlayersCountExceptGMs();
+                    amount *= (float)currentPlayerCount / maxPlayerCount;
+                }
+            }
         }
 };
 

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -110,7 +110,7 @@ static std::map<int, int> forcedCreatureIds;
 // Another value TODO in player class for the party leader's value to determine dungeon difficulty.
 static int8 PlayerCountDifficultyOffset, LevelScaling, higherOffset, lowerOffset;
 static uint32 rewardRaid, rewardDungeon, MinPlayerReward;
-static bool enabled, LevelEndGameBoost, DungeonsOnly, PlayerChangeNotify, LevelUseDb, rewardEnabled;
+static bool enabled, LevelEndGameBoost, DungeonsOnly, PlayerChangeNotify, LevelUseDb, rewardEnabled, FullGroupXP;
 static float globalRate, healthMultiplier, manaMultiplier, armorMultiplier, damageMultiplier, MinHPModifier, MinManaModifier, MinDamageModifier, InflectionPoint;
 
 int GetValidDebugLevel()
@@ -193,12 +193,13 @@ class AutoBalance_WorldScript : public WorldScript
         LoadForcedCreatureIdsFromString(sConfigMgr->GetStringDefault("AutoBalance.ForcedID2", ""), 2);
         LoadForcedCreatureIdsFromString(sConfigMgr->GetStringDefault("AutoBalance.DisabledID", ""), 0);
 
-        enabled = sConfigMgr->GetIntDefault("AutoBalance.enable", 1) == 1;
-        LevelEndGameBoost = sConfigMgr->GetIntDefault("AutoBalance.LevelEndGameBoost", 1) == 1;
-        DungeonsOnly = sConfigMgr->GetIntDefault("AutoBalance.DungeonsOnly", 1) == 1;
-        PlayerChangeNotify = sConfigMgr->GetIntDefault("AutoBalance.PlayerChangeNotify", 1) == 1;
-        LevelUseDb = sConfigMgr->GetIntDefault("AutoBalance.levelUseDbValuesWhenExists", 1) == 1;
-        rewardEnabled = sConfigMgr->GetIntDefault("AutoBalance.reward.enable", 1) == 1;
+        enabled = sConfigMgr->GetBoolDefault("AutoBalance.enable", 1);
+        LevelEndGameBoost = sConfigMgr->GetBoolDefault("AutoBalance.LevelEndGameBoost", 1);
+        DungeonsOnly = sConfigMgr->GetBoolDefault("AutoBalance.DungeonsOnly", 1);
+        PlayerChangeNotify = sConfigMgr->GetBoolDefault("AutoBalance.PlayerChangeNotify", 1);
+        LevelUseDb = sConfigMgr->GetBoolDefault("AutoBalance.levelUseDbValuesWhenExists", 1);
+        rewardEnabled = sConfigMgr->GetBoolDefault("AutoBalance.reward.enable", 1);
+        FullGroupXP = sConfigMgr->GetBoolDefault("AutoBalance.DungeonFullGroupXP", 0);
 
         LevelScaling = sConfigMgr->GetIntDefault("AutoBalance.levelScaling", 1);
         PlayerCountDifficultyOffset = sConfigMgr->GetIntDefault("AutoBalance.playerCountDifficultyOffset", 0);
@@ -251,7 +252,7 @@ class AutoBalance_PlayerScript : public PlayerScript
 
         void OnGiveXP(Player* player, uint32& amount, Unit* victim) override
         {
-            if (victim && sConfigMgr->GetBoolDefault("AutoBalance.DungeonFullGroupXP", 0))
+            if (victim && FullGroupXP)
             {
                 Map* map = player->GetMap();
 

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -108,10 +108,10 @@ public:
 static std::map<int, int> forcedCreatureIds;
 // cheaphack for difficulty server-wide.
 // Another value TODO in player class for the party leader's value to determine dungeon difficulty.
-static int8 PlayerCountDifficultyOffset, LevelScaling, higherOffset, lowerOffset, numPlayerConf;
+static int8 PlayerCountDifficultyOffset, LevelScaling, higherOffset, lowerOffset;
 static uint32 rewardRaid, rewardDungeon, MinPlayerReward;
 static bool enabled, LevelEndGameBoost, DungeonsOnly, PlayerChangeNotify, LevelUseDb, rewardEnabled;
-static float globalRate, healthMultiplier, manaMultiplier, armorMultiplier, damageMultiplier, MinHPModifier, MinDamageModifier, InflectionPoint;
+static float globalRate, healthMultiplier, manaMultiplier, armorMultiplier, damageMultiplier, MinHPModifier, MinManaModifier, MinDamageModifier, InflectionPoint;
 
 int GetValidDebugLevel()
 {
@@ -214,8 +214,8 @@ class AutoBalance_WorldScript : public WorldScript
         manaMultiplier = sConfigMgr->GetFloatDefault("AutoBalance.rate.mana", 1.0f);
         armorMultiplier = sConfigMgr->GetFloatDefault("AutoBalance.rate.armor", 1.0f);
         damageMultiplier = sConfigMgr->GetFloatDefault("AutoBalance.rate.damage", 1.0f);
-        numPlayerConf=sConfigMgr->GetFloatDefault("AutoBalance.numPlayer", 1.0f);
         MinHPModifier = sConfigMgr->GetFloatDefault("AutoBalance.MinHPModifier", 0.1f);
+        MinManaModifier = sConfigMgr->GetFloatDefault("AutoBalance.MinManaModifier", 0.1f);
         MinDamageModifier = sConfigMgr->GetFloatDefault("AutoBalance.MinDamageModifier", 0.1f);
     }
 };
@@ -610,6 +610,12 @@ public:
         }
 
         creatureABInfo->ManaMultiplier =  manaStatsRate * manaMultiplier * defaultMultiplier * globalRate;
+
+        if (creatureABInfo->ManaMultiplier <= MinManaModifier)
+        {
+            creatureABInfo->ManaMultiplier = MinManaModifier;
+        }
+
         scaledMana = round(baseMana * creatureABInfo->ManaMultiplier);
 
         float damageMul = defaultMultiplier * globalRate * damageMultiplier;

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -110,7 +110,7 @@ static std::map<int, int> forcedCreatureIds;
 // Another value TODO in player class for the party leader's value to determine dungeon difficulty.
 static int8 PlayerCountDifficultyOffset, LevelScaling, higherOffset, lowerOffset;
 static uint32 rewardRaid, rewardDungeon, MinPlayerReward;
-static bool enabled, LevelEndGameBoost, DungeonsOnly, PlayerChangeNotify, LevelUseDb, rewardEnabled, FullGroupXP;
+static bool enabled, LevelEndGameBoost, DungeonsOnly, PlayerChangeNotify, LevelUseDb, rewardEnabled, DungeonScaleDownXP;
 static float globalRate, healthMultiplier, manaMultiplier, armorMultiplier, damageMultiplier, MinHPModifier, MinManaModifier, MinDamageModifier, InflectionPoint;
 
 int GetValidDebugLevel()
@@ -199,7 +199,7 @@ class AutoBalance_WorldScript : public WorldScript
         PlayerChangeNotify = sConfigMgr->GetBoolDefault("AutoBalance.PlayerChangeNotify", 1);
         LevelUseDb = sConfigMgr->GetBoolDefault("AutoBalance.levelUseDbValuesWhenExists", 1);
         rewardEnabled = sConfigMgr->GetBoolDefault("AutoBalance.reward.enable", 1);
-        FullGroupXP = sConfigMgr->GetBoolDefault("AutoBalance.DungeonFullGroupXP", 0);
+        DungeonScaleDownXP = sConfigMgr->GetBoolDefault("AutoBalance.DungeonScaleDownXP", 0);
 
         LevelScaling = sConfigMgr->GetIntDefault("AutoBalance.levelScaling", 1);
         PlayerCountDifficultyOffset = sConfigMgr->GetIntDefault("AutoBalance.playerCountDifficultyOffset", 0);
@@ -252,7 +252,7 @@ class AutoBalance_PlayerScript : public PlayerScript
 
         void OnGiveXP(Player* player, uint32& amount, Unit* victim) override
         {
-            if (victim && FullGroupXP)
+            if (victim && DungeonScaleDownXP)
             {
                 Map* map = player->GetMap();
 


### PR DESCRIPTION
- Add a new config option "MinManaModifier". There's "MinHPModifier", "MinDamageModifier" but no option for a minimum Mana modifier. This is useful because sometimes the Mana of the creatures can drop too low so that they cannot use their spells anymore (e.g. Ragefire Chasm, creature "Ragefire Shaman", entering with level 16 character). This way you can specify a minimum just like for HP or damage.
- Add a new config option "DungeonScaleDownXP". If enabled this option ensures that the player always gets the same XP as if he entered the dungeon with a full group. This can be used to slow down leveling especially when playing solo (some players don't want to gain multiple levels per dungeon run).
- Removed the unused option "AutoBalance.Instances"
- Also removed "numPlayer" from the code as this has been forgotten in commit e5c6345.