### PR TITLE
Add boss scaling

### DIFF
--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -51,8 +51,8 @@ AutoBalance.InflectionPointRaid10MHeroic=0.5
 
 #
 #     AutoBalance.BossInflectionMult
-#        Multiplies the inflection point of bosses, only applies to creatures considered dungeon bosses, 
-#		 such as those from dungeons or raids.
+#        Multiplies the inflection point of bosses, only applies to creatures considered dungeon bosses (from dungeons or raids).
+#        Example: If AutoBalance.BossInflectionMult = 0.4 and AutoBalance.InflectionPoint=0.5, the bosses inflection point will be 0.4*0.9 = 0.36 in a normal dungeon.
 #        Default:     1.0
 
 AutoBalance.BossInflectionMult=1.0

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -50,6 +50,14 @@ AutoBalance.InflectionPointRaid25MHeroic=0.5
 AutoBalance.InflectionPointRaid10MHeroic=0.5
 
 #
+#     AutoBalance.BossInflectionMult
+#        Multiplies the inflection point of bosses, only applies to creatures considered dungeon bosses, 
+#		 such as those from dungeons or raids.
+#        Default:     1.0
+
+AutoBalance.BossInflectionMult=1.0
+
+#
 #     AutoBalance.levelScaling
 #        Check the max level of players in map and scale creature based on it.
 #        This triggers depending on the two options below AutoBalance.levelHigherOffset and AutoBalance.levelLowerOffset

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -111,7 +111,8 @@ static std::map<int, int> forcedCreatureIds;
 static int8 PlayerCountDifficultyOffset, LevelScaling, higherOffset, lowerOffset;
 static uint32 rewardRaid, rewardDungeon, MinPlayerReward;
 static bool enabled, LevelEndGameBoost, DungeonsOnly, PlayerChangeNotify, LevelUseDb, rewardEnabled, DungeonScaleDownXP;
-static float globalRate, healthMultiplier, manaMultiplier, armorMultiplier, damageMultiplier, MinHPModifier, MinManaModifier, MinDamageModifier, InflectionPoint, InflectionPointRaid, InflectionPointRaid10M, InflectionPointRaid25M, InflectionPointHeroic, InflectionPointRaidHeroic, InflectionPointRaid10MHeroic, InflectionPointRaid25MHeroic;
+static float globalRate, healthMultiplier, manaMultiplier, armorMultiplier, damageMultiplier, MinHPModifier, MinManaModifier, MinDamageModifier,
+InflectionPoint, InflectionPointRaid, InflectionPointRaid10M, InflectionPointRaid25M, InflectionPointHeroic, InflectionPointRaidHeroic, InflectionPointRaid10MHeroic, InflectionPointRaid25MHeroic, BossInflectionMult;
 
 int GetValidDebugLevel()
 {
@@ -217,6 +218,7 @@ class AutoBalance_WorldScript : public WorldScript
         InflectionPointRaidHeroic = sConfigMgr->GetFloatDefault("AutoBalance.InflectionPointRaidHeroic", InflectionPointRaid);
         InflectionPointRaid25MHeroic = sConfigMgr->GetFloatDefault("AutoBalance.InflectionPointRaid25MHeroic", InflectionPointRaid25M);
         InflectionPointRaid10MHeroic = sConfigMgr->GetFloatDefault("AutoBalance.InflectionPointRaid10MHeroic", InflectionPointRaid10M);
+        BossInflectionMult = sConfigMgr->GetFloatDefault("AutoBalance.BossInflectionMult", 1.0f);
         globalRate = sConfigMgr->GetFloatDefault("AutoBalance.rate.global", 1.0f);
         healthMultiplier = sConfigMgr->GetFloatDefault("AutoBalance.rate.health", 1.0f);
         manaMultiplier = sConfigMgr->GetFloatDefault("AutoBalance.rate.mana", 1.0f);
@@ -620,6 +622,9 @@ public:
                 }
                 else
                     inflectionValue *= InflectionPoint;
+            }
+            if (creature->IsDungeonBoss()) {
+                inflectionValue *= BossInflectionMult;
             }
 
             float diff = ((float)maxNumberOfPlayers/5)*1.5f;


### PR DESCRIPTION
Adds separate scaling for bosses, in the form of a conf option BossInflectionMult, which is multiplied by the regular inflection point for the content if the creature is a dungeon boss.

Closes https://github.com/azerothcore/mod-autobalance/issues/47