### PR TITLE
Only announce the module if it is also enabled

### DIFF
--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -8,7 +8,7 @@
 # AUTOBALANCE ANNOUNCE
 #
 #     AutoBalanceAnnounce.enable
-#        Announce the module on login
+#        Announce the module on login if it is enabled
 #        Default:     1 (1 = ON, 0 = OFF)
 
 AutoBalanceAnnounce.enable=1

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -269,7 +269,7 @@ class AutoBalance_PlayerScript : public PlayerScript
 
         void OnLogin(Player *Player) override
         {
-            if (sConfigMgr->GetOption<bool>("AutoBalanceAnnounce.enable", true)) {
+            if (sConfigMgr->GetOption<bool>("AutoBalanceAnnounce.enable", true)) && (sConfigMgr->GetOption<bool>("AutoBalance.enable", true)) {
                 ChatHandler(Player->GetSession()).SendSysMessage("This server is running the |cff4CFF00AutoBalance |rmodule.");
             }
         }

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -269,7 +269,7 @@ class AutoBalance_PlayerScript : public PlayerScript
 
         void OnLogin(Player *Player) override
         {
-            if (sConfigMgr->GetOption<bool>("AutoBalanceAnnounce.enable", true)) && (sConfigMgr->GetOption<bool>("AutoBalance.enable", true)) {
+            if ((sConfigMgr->GetOption<bool>("AutoBalanceAnnounce.enable", true)) && (sConfigMgr->GetOption<bool>("AutoBalance.enable", true))) {
                 ChatHandler(Player->GetSession()).SendSysMessage("This server is running the |cff4CFF00AutoBalance |rmodule.");
             }
         }


### PR DESCRIPTION
Creates a check to see if the module is enabled in the config before announcing it. Doesn't make any sense to announce the module if it isn't even running.

Currently untested, only know that it compiles.