### PR TITLE
feat: Add Per-dungeon scaling options

### DIFF
--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -110,6 +110,17 @@ AutoBalance.LevelEndGameBoost = 1
 AutoBalance.DungeonScaleDownXP = 0
 
 #
+#     AutoBalance.DungeonScaleDownMoney
+#        Decrease individual player's amount of money gained during a dungeon to match the
+#        amount of money gained during a full group run. Example: In a 5-man group, you
+#        earn 1/5 of the total money per kill, but if you solo the dungeon with
+#        AutoBalance.DungeonScaleDownMoney = 0, you will earn 5/5 of the total money.
+#        With the option enabled, you will earn 1/5.
+#        Default:     0 (1 = ON, 0 = OFF)
+
+AutoBalance.DungeonScaleDownMoney = 0
+
+#
 #     AutoBalance.DungeonsOnly
 #        Only apply scaling changes to dungeons and raids
 #        Default:     1 (1 = ON, 0 = OFF)

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -195,6 +195,42 @@ AutoBalance.ForcedID2=""
 
 AutoBalance.DisabledID=""
 
+#
+#     AutoBalance.PerDungeonPlayerCounts
+#        Allows setting a per-dungeon setting for minimum number of players to scale. For example, dungeons could remain at 5 players, but raids could be chosen to scale down to 5 players as well.
+#        Formatted as "[dungeonId] [playerCount], [dungeonId] [playerCount], [dungeonId] [playerCount], ..."
+#        Example: AutoBalance.PerDungeonPlayerCounts="33 1,34 1,36 1,43 1,47 1,48 1,70 1,90 1,109 1,129 1,189 1,209 1,349 1,389 1, 289 2, 329 2, 230 2, 429 2, 309 5, 409 5"
+#        For dungeons not listed, the dungeon's original player count (5, 10, 20, 25, or 40) is used as the minimum, meaning no scaling will take place.
+#        To disable, leave empty; all dungeons will then scale down to 1 player minimum. This is the default setting.
+#        Default: ""
+#
+
+AutoBalance.PerDungeonPlayerCounts=""
+
+#
+#     AutoBalance.PerDungeonScaling
+#        Allows setting a per-dungeon scaling inflection value
+#        Formatted as "[dungeonId] [inflectionValue], [dungeonId] [inflectionValue], [dungeonId] [inflectionValue], ..."
+#        Example: AutoBalance.PerDungeonScaling="229 0.15, 309 0.3"
+#        For dungeons not listed, the default inflection value provided above for the dungeon's difficulty will be used.
+#        To disable, leave empty. This is the default setting.
+#        Default: ""
+#
+
+AutoBalance.PerDungeonScaling=""
+
+#
+#     AutoBalance.PerDungeonBossScaling
+#        Allows setting a per-dungeon scaling inflection value for bosses
+#        Formatted as "[dungeonId] [inflectionValue], [dungeonId] [inflectionValue], [dungeonId] [inflectionValue], ..."
+#        Example: AutoBalance.PerDungeonBossScaling="229 0.5, 309 1.2, 409 1, 249 1.5"
+#        For dungeons not listed, the default inflection value provided above for the dungeon's difficulty will be used.
+#        To disable, leave empty. This is the default setting.
+#        Default: ""
+#
+
+AutoBalance.PerDungeonBossScaling=""
+
 ##########################
 #
 # REWARD SYSTEM (experimental)

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -168,8 +168,8 @@ void LoadEnabledDungeons(std::string dungeonIdString) // Used for reading the st
         std::string pairOne, pairTwo;
         std::stringstream dungeonPairStream(delimitedValue);
         dungeonPairStream>>pairOne>>pairTwo;
-        uint32 dungeonMapId = atoi(pairOne.c_str());
-        uint8 minPlayers = atoi(pairTwo.c_str());
+        auto dungeonMapId = atoi(pairOne.c_str());
+        auto minPlayers = atoi(pairTwo.c_str());
         enabledDungeonIds[dungeonMapId] = minPlayers;
     }
 }
@@ -185,8 +185,8 @@ void LoadDungeonOverrides(std::string dungeonIdString) // Used for reading the s
         std::string pairOne, pairTwo;
         std::stringstream dungeonPairStream(delimitedValue);
         dungeonPairStream>>pairOne>>pairTwo;
-        uint32 dungeonMapId = atoi(pairOne.c_str());
-        float dungeonInflection = atof(pairTwo.c_str());
+        auto dungeonMapId = atoi(pairOne.c_str());
+        auto dungeonInflection = atof(pairTwo.c_str());
         dungeonOverrides[dungeonMapId] = dungeonInflection;
     }
 }
@@ -202,8 +202,8 @@ void LoadBossOverrides(std::string dungeonIdString) // Used for reading the stri
         std::string pairOne, pairTwo;
         std::stringstream dungeonPairStream(delimitedValue);
         dungeonPairStream>>pairOne>>pairTwo;
-        uint32 dungeonMapId = atoi(pairOne.c_str());
-        float bossInflection = atof(pairTwo.c_str());
+        auto dungeonMapId = atoi(pairOne.c_str());
+        auto bossInflection = atof(pairTwo.c_str());
         bossOverrides[dungeonMapId] = bossInflection;
     }
 }
@@ -379,8 +379,8 @@ class AutoBalance_PlayerScript : public PlayerScript
                 if (map->IsDungeon())
                 {
                     // Ensure that the players always get the same XP, even when entering the dungeon alone
-                    uint32 maxPlayerCount = ((InstanceMap*)sMapMgr->FindMap(map->GetId(), map->GetInstanceId()))->GetMaxPlayers();
-                    uint32 currentPlayerCount = map->GetPlayersCountExceptGMs();
+                    auto maxPlayerCount = ((InstanceMap*)sMapMgr->FindMap(map->GetId(), map->GetInstanceId()))->GetMaxPlayers();
+                    auto currentPlayerCount = map->GetPlayersCountExceptGMs();
                     amount *= (float)currentPlayerCount / maxPlayerCount;
                 }
             }
@@ -394,9 +394,9 @@ class AutoBalance_PlayerScript : public PlayerScript
 
                 if (map->IsDungeon())
                 {
-                    // Ensure that the players always get the same XP, even when entering the dungeon alone
-                    uint32 maxPlayerCount = ((InstanceMap*)sMapMgr->FindMap(map->GetId(), map->GetInstanceId()))->GetMaxPlayers();
-                    uint32 currentPlayerCount = map->GetPlayersCountExceptGMs();
+                    // Ensure that the players always get the same money, even when entering the dungeon alone
+                    auto maxPlayerCount = ((InstanceMap*)sMapMgr->FindMap(map->GetId(), map->GetInstanceId()))->GetMaxPlayers();
+                    auto currentPlayerCount = map->GetPlayersCountExceptGMs();
                     loot->gold *= uint32((float)currentPlayerCount / (float)maxPlayerCount);
                 }
             }

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -209,22 +209,22 @@ void LoadBossOverrides(std::string dungeonIdString) // Used for reading the stri
 }
 
 
-boolean isEnabledDungeon(uint32 dungeonId)
+bool isEnabledDungeon(uint32 dungeonId)
 {
     return (enabledDungeonIds.find(dungeonId) != enabledDungeonIds.end());
 }
 
-boolean perDungeonScalingEnabled()
+bool perDungeonScalingEnabled()
 {
     return (!enabledDungeonIds.empty());
 }
 
-boolean hasDungeonOverride(uint32 dungeonId)
+bool hasDungeonOverride(uint32 dungeonId)
 {
     return (dungeonOverrides.find(dungeonId) != dungeonOverrides.end());
 }
 
-boolean hasBossOverride(uint32 dungeonId)
+bool hasBossOverride(uint32 dungeonId)
 {
     return (bossOverrides.find(dungeonId) != bossOverrides.end());
 }

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -135,6 +135,9 @@ public:
 
 // The map values correspond with the .AutoBalance.XX.Name entries in the configuration file.
 static std::map<int, int> forcedCreatureIds;
+static std::map<uint32, uint8> enabledDungeonIds;
+static std::map<uint32, float> dungeonOverrides;
+static std::map<uint32, float> bossOverrides;
 // cheaphack for difficulty server-wide.
 // Another value TODO in player class for the party leader's value to determine dungeon difficulty.
 static int8 PlayerCountDifficultyOffset, LevelScaling, higherOffset, lowerOffset;
@@ -152,6 +155,78 @@ int GetValidDebugLevel()
         return 1;
         }
     return debugLevel;
+}
+
+void LoadEnabledDungeons(std::string dungeonIdString) // Used for reading the string from the configuration file for selecting dungeons to scale
+{
+    std::string delimitedValue;
+    std::stringstream dungeonIdStream;
+
+    dungeonIdStream.str(dungeonIdString);
+    while (std::getline(dungeonIdStream, delimitedValue, ',')) // Process each dungeon ID in the string, delimited by the comma - "," and then space " "
+    {
+        std::string pairOne, pairTwo;
+        std::stringstream dungeonPairStream(delimitedValue);
+        dungeonPairStream>>pairOne>>pairTwo;
+        uint32 dungeonMapId = atoi(pairOne.c_str());
+        uint8 minPlayers = atoi(pairTwo.c_str());
+        enabledDungeonIds[dungeonMapId] = minPlayers;
+    }
+}
+
+void LoadDungeonOverrides(std::string dungeonIdString) // Used for reading the string from the configuration file for selecting dungeons to override
+{
+    std::string delimitedValue;
+    std::stringstream dungeonIdStream;
+
+    dungeonIdStream.str(dungeonIdString);
+    while (std::getline(dungeonIdStream, delimitedValue, ',')) // Process each dungeon ID in the string, delimited by the comma - "," and then space " "
+    {
+        std::string pairOne, pairTwo;
+        std::stringstream dungeonPairStream(delimitedValue);
+        dungeonPairStream>>pairOne>>pairTwo;
+        uint32 dungeonMapId = atoi(pairOne.c_str());
+        float dungeonInflection = atof(pairTwo.c_str());
+        dungeonOverrides[dungeonMapId] = dungeonInflection;
+    }
+}
+
+void LoadBossOverrides(std::string dungeonIdString) // Used for reading the string from the configuration file for selecting dungeons to override boss inflection
+{
+    std::string delimitedValue;
+    std::stringstream dungeonIdStream;
+
+    dungeonIdStream.str(dungeonIdString);
+    while (std::getline(dungeonIdStream, delimitedValue, ',')) // Process each dungeon ID in the string, delimited by the comma - "," and then space " "
+    {
+        std::string pairOne, pairTwo;
+        std::stringstream dungeonPairStream(delimitedValue);
+        dungeonPairStream>>pairOne>>pairTwo;
+        uint32 dungeonMapId = atoi(pairOne.c_str());
+        float bossInflection = atof(pairTwo.c_str());
+        bossOverrides[dungeonMapId] = bossInflection;
+    }
+}
+
+
+boolean isEnabledDungeon(uint32 dungeonId)
+{
+    return (enabledDungeonIds.find(dungeonId) != enabledDungeonIds.end());
+}
+
+boolean perDungeonScalingEnabled()
+{
+    return (!enabledDungeonIds.empty());
+}
+
+boolean hasDungeonOverride(uint32 dungeonId)
+{
+    return (dungeonOverrides.find(dungeonId) != dungeonOverrides.end());
+}
+
+boolean hasBossOverride(uint32 dungeonId)
+{
+    return (bossOverrides.find(dungeonId) != bossOverrides.end());
 }
 
 void LoadForcedCreatureIdsFromString(std::string creatureIds, int forcedPlayerCount) // Used for reading the string from the configuration file to for those creatures who need to be scaled for XX number of players.
@@ -216,12 +291,18 @@ class AutoBalance_WorldScript : public WorldScript
     void SetInitialWorldSettings()
     {
         forcedCreatureIds.clear();
+        enabledDungeonIds.clear();
+        dungeonOverrides.clear();
+        bossOverrides.clear();
         LoadForcedCreatureIdsFromString(sConfigMgr->GetOption<std::string>("AutoBalance.ForcedID40", ""), 40);
         LoadForcedCreatureIdsFromString(sConfigMgr->GetOption<std::string>("AutoBalance.ForcedID25", ""), 25);
         LoadForcedCreatureIdsFromString(sConfigMgr->GetOption<std::string>("AutoBalance.ForcedID10", ""), 10);
         LoadForcedCreatureIdsFromString(sConfigMgr->GetOption<std::string>("AutoBalance.ForcedID5", ""), 5);
         LoadForcedCreatureIdsFromString(sConfigMgr->GetOption<std::string>("AutoBalance.ForcedID2", ""), 2);
         LoadForcedCreatureIdsFromString(sConfigMgr->GetOption<std::string>("AutoBalance.DisabledID", ""), 0);
+        LoadEnabledDungeons(sConfigMgr->GetOption<std::string>("AutoBalance.PerDungeonPlayerCounts", ""));
+        LoadDungeonOverrides(sConfigMgr->GetOption<std::string>("AutoBalance.PerDungeonScaling", ""));
+        LoadBossOverrides(sConfigMgr->GetOption<std::string>("AutoBalance.PerDungeonBossScaling", ""));
 
         enabled = sConfigMgr->GetOption<bool>("AutoBalance.enable", 1);
         LevelEndGameBoost = sConfigMgr->GetOption<bool>("AutoBalance.LevelEndGameBoost", 1);
@@ -547,6 +628,11 @@ public:
         CreatureTemplate const *creatureTemplate = creature->GetCreatureTemplate();
 
         InstanceMap* instanceMap = ((InstanceMap*)sMapMgr->FindMap(creature->GetMapId(), creature->GetInstanceId()));
+        uint32 mapId = instanceMap->GetEntry()->MapID;
+        if (perDungeonScalingEnabled() && !isEnabledDungeon(mapId))
+        {
+            return;
+        }
         uint32 maxNumberOfPlayers = instanceMap->GetMaxPlayers();
         int forcedNumPlayers = GetForcedNumPlayers(creatureTemplate->Entry);
 
@@ -570,6 +656,10 @@ public:
             return;
 
         uint32 curCount=mapABInfo->playerCount + PlayerCountDifficultyOffset;
+        if (perDungeonScalingEnabled())
+        {
+            curCount = adjustCurCount(curCount, mapId);
+        }
 
         uint8 bonusLevel = creatureTemplate->rank == CREATURE_ELITE_WORLDBOSS ? 3 : 0;
         // already scaled
@@ -644,47 +734,60 @@ public:
         if (creatureABInfo->instancePlayerCount < maxNumberOfPlayers)
         {
             float inflectionValue  = (float)maxNumberOfPlayers;
-
-            if (instanceMap->IsHeroic())
+            if (hasDungeonOverride(mapId))
             {
-                if (instanceMap->IsRaid())
-                {
-                    switch (instanceMap->GetMaxPlayers())
-                    {
-                        case 10:
-                            inflectionValue *= InflectionPointRaid10MHeroic;
-                            break;
-                        case 25:
-                            inflectionValue *= InflectionPointRaid25MHeroic;
-                            break;
-                        default:
-                            inflectionValue *= InflectionPointRaidHeroic;
-                    }
-                }
-                else
-                    inflectionValue *= InflectionPointHeroic;
+                inflectionValue *= dungeonOverrides[mapId];
             }
             else
             {
-                if (instanceMap->IsRaid())
+                if (instanceMap->IsHeroic())
                 {
-                    switch (instanceMap->GetMaxPlayers())
+                    if (instanceMap->IsRaid())
                     {
-                        case 10:
-                            inflectionValue *= InflectionPointRaid10M;
-                            break;
-                        case 25:
-                            inflectionValue *= InflectionPointRaid25M;
-                            break;
-                        default:
-                            inflectionValue *= InflectionPointRaid;
+                        switch (instanceMap->GetMaxPlayers())
+                        {
+                            case 10:
+                                inflectionValue *= InflectionPointRaid10MHeroic;
+                                break;
+                            case 25:
+                                inflectionValue *= InflectionPointRaid25MHeroic;
+                                break;
+                            default:
+                                inflectionValue *= InflectionPointRaidHeroic;
+                        }
                     }
+                    else
+                        inflectionValue *= InflectionPointHeroic;
                 }
                 else
-                    inflectionValue *= InflectionPoint;
+                {
+                    if (instanceMap->IsRaid())
+                    {
+                        switch (instanceMap->GetMaxPlayers())
+                        {
+                            case 10:
+                                inflectionValue *= InflectionPointRaid10M;
+                                break;
+                            case 25:
+                                inflectionValue *= InflectionPointRaid25M;
+                                break;
+                            default:
+                                inflectionValue *= InflectionPointRaid;
+                        }
+                    }
+                    else
+                        inflectionValue *= InflectionPoint;
+                }
             }
             if (creature->IsDungeonBoss()) {
-                inflectionValue *= BossInflectionMult;
+                if (hasBossOverride(mapId))
+                {
+                    inflectionValue *= bossOverrides[mapId];
+                }
+                else
+                {
+                    inflectionValue *= BossInflectionMult;
+                }
             }
 
             float diff = ((float)maxNumberOfPlayers/5)*1.5f;
@@ -813,6 +916,13 @@ public:
             creature->setPowerType(pType); // fix creatures with different power types
 
         creature->UpdateAllStats();
+    }
+
+private:
+    uint32 adjustCurCount(uint32 inputCount, uint32 dungeonId)
+    {
+        uint8 minPlayers = enabledDungeonIds[dungeonId];
+        return inputCount < minPlayers ? minPlayers : inputCount;
     }
 };
 class AutoBalance_CommandScript : public CommandScript


### PR DESCRIPTION
Adds options to allow:

- Setting per-dungeon minimum player count
- Setting per-dungeon inflection value
- Setting per-dungeon boss inflection value

All options are disabled by default.