### PR TITLE
Fix for dungeon gold always scaled to 0

### DIFF
--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -397,7 +397,7 @@ class AutoBalance_PlayerScript : public PlayerScript
                     // Ensure that the players always get the same money, even when entering the dungeon alone
                     auto maxPlayerCount = ((InstanceMap*)sMapMgr->FindMap(map->GetId(), map->GetInstanceId()))->GetMaxPlayers();
                     auto currentPlayerCount = map->GetPlayersCountExceptGMs();
-                    loot->gold *= uint32((float)currentPlayerCount / (float)maxPlayerCount);
+                    loot->gold *= (float)currentPlayerCount / (float)maxPlayerCount;
                 }
             }
 

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -397,7 +397,7 @@ class AutoBalance_PlayerScript : public PlayerScript
                     // Ensure that the players always get the same money, even when entering the dungeon alone
                     auto maxPlayerCount = ((InstanceMap*)sMapMgr->FindMap(map->GetId(), map->GetInstanceId()))->GetMaxPlayers();
                     auto currentPlayerCount = map->GetPlayersCountExceptGMs();
-                    loot->gold *= (float)currentPlayerCount / (float)maxPlayerCount;
+                    loot->gold = uint32(loot->gold * ((float)currentPlayerCount / (float)maxPlayerCount));
                 }
             }
 


### PR DESCRIPTION
Scale ratio was being converted to unsigned int so when there was less than `maxPlayerCount` players in the group, the gold reward would always be 0 after looting when using `DungeonScaleDownMoney = 1`.