### PR TITLE
Experience gain

### DIFF
--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -128,6 +128,13 @@ AutoBalance.DungeonScaleDownMoney = 0
 AutoBalance.DungeonsOnly=1
 
 #
+#     AutoBalance.CountNpcBots
+#        NPCBots mod integration. Makes bots count as players for player count calculation
+#        Default:     1 (1 = ON, 0 = OFF)
+
+AutoBalance.CountNpcBots=1
+
+#
 #     AutoBalance.DebugLevel
 #        0 = None
 #        1 = Errors Only

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -264,8 +264,8 @@ int GetForcedNumPlayers(int creatureId)
 void getAreaLevel(Map *map, uint8 areaid, uint8 &min, uint8 &max) {
     LFGDungeonEntry const* dungeon = GetLFGDungeon(map->GetId(), map->GetDifficulty());
     if (dungeon && (map->IsDungeon() || map->IsRaid())) {
-        min  = dungeon->minlevel;
-        max  = dungeon->reclevel ? dungeon->reclevel : dungeon->maxlevel;
+        min  = dungeon->MinLevel;
+        max  = dungeon->TargetLevel ? dungeon->TargetLevel : dungeon->MaxLevel;
     }
 
     if (!min && !max)

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -456,7 +456,7 @@ class AutoBalance_UnitScript : public UnitScript
         damage = _Modifer_DealDamage(target, attacker, damage);
     }
 
-    void ModifySpellDamageTaken(Unit* target, Unit* attacker, int32& damage) override
+    void ModifySpellDamageTaken(Unit* target, Unit* attacker, int32& damage, SpellInfo const*) override
     {
         damage = _Modifer_DealDamage(target, attacker, damage);
     }

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -1120,6 +1120,17 @@ public:
     }
 };
 
+//npcbot
+class ABModuleNPCBots : public ABModuleScript
+{
+public:
+    ABModuleNPCBots() : ABModuleScript("ABModuleNPCBots") {}
+
+    bool OnBeforeModifyAttributes(Creature* creature, uint32& /*instancePlayerCount*/) override { return !creature->IsNPCBotOrPet(); }
+    bool OnAfterDefaultMultiplier(Creature* creature, float& /*defaultMultiplier*/) override { return !creature->IsNPCBotOrPet(); }
+    bool OnBeforeUpdateStats(Creature* creature, uint32& /*scaledHealth*/, uint32& /*scaledMana*/, float& /*damageMultiplier*/, uint32& /*newBaseArmor*/) override { return !creature->IsNPCBotOrPet(); }
+};
+//end npcbot
 
 
 void AddAutoBalanceScripts()
@@ -1131,4 +1142,7 @@ void AddAutoBalanceScripts()
     new AutoBalance_AllMapScript();
     new AutoBalance_CommandScript();
     new AutoBalance_GlobalScript();
+    //npcbot
+    new ABModuleNPCBots();
+    //end npcbot
 }

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -348,7 +348,7 @@ class AutoBalance_WorldScript : public WorldScript
         //end npcbot
 
         LevelScaling = sConfigMgr->GetOption<uint32>("AutoBalance.levelScaling", 1);
-        PlayerCountDifficultyOffset = sConfigMgr->GetOption<uint32>("AutoBalance.playerCountDifficultyOffset", 0);
+        PlayerCountDifficultyOffset = sConfigMgr->GetOption<int32>("AutoBalance.playerCountDifficultyOffset", 0);
         higherOffset = sConfigMgr->GetOption<uint32>("AutoBalance.levelHigherOffset", 3);
         lowerOffset = sConfigMgr->GetOption<uint32>("AutoBalance.levelLowerOffset", 0);
         rewardRaid = sConfigMgr->GetOption<uint32>("AutoBalance.reward.raidToken", 49426);
@@ -536,7 +536,7 @@ class AutoBalance_AllMapScript : public AllMapScript
             if (PlayerChangeNotify) {
                 for (MapReference const& ref : map->GetPlayers()) {
                     if (Player const* playerHandle = ref.GetSource()) {
-                        ChatHandler(playerHandle->GetSession()).PSendSysMessage("|cffFF0000 [AutoBalance+NPCBots]|r|cffFF8000 %s's bots entered %s. Auto setting player count to %u (Player Difficulty Offset = %u) |r", player->GetName().c_str(), map->GetMapName(), mapABInfo->playerCount + PlayerCountDifficultyOffset, PlayerCountDifficultyOffset);
+                        ChatHandler(playerHandle->GetSession()).PSendSysMessage("|cffFF0000 [AutoBalance+NPCBots]|r|cffFF8000 %s's bots entered %s. Auto setting player count to %i (Player Difficulty Offset = %i) |r", player->GetName().c_str(), map->GetMapName(), mapABInfo->playerCount + PlayerCountDifficultyOffset, PlayerCountDifficultyOffset);
                     }
                 }
             }
@@ -597,7 +597,7 @@ class AutoBalance_AllMapScript : public AllMapScript
                             if (Player* playerHandle = playerIteration->GetSource())
                             {
                                 ChatHandler chatHandle = ChatHandler(playerHandle->GetSession());
-                                chatHandle.PSendSysMessage("|cffFF0000 [AutoBalance]|r|cffFF8000 %s entered %s. Auto setting player count to %u (Player Difficulty Offset = %u) |r", player->GetName().c_str(), map->GetMapName(), mapABInfo->playerCount + PlayerCountDifficultyOffset, PlayerCountDifficultyOffset);
+                                chatHandle.PSendSysMessage("|cffFF0000 [AutoBalance]|r|cffFF8000 %s entered %s. Auto setting player count to %i (Player Difficulty Offset = %i) |r", player->GetName().c_str(), map->GetMapName(), mapABInfo->playerCount + PlayerCountDifficultyOffset, PlayerCountDifficultyOffset);
                             }
                         }
                     }
@@ -671,7 +671,7 @@ class AutoBalance_AllMapScript : public AllMapScript
                             if (Player* playerHandle = playerIteration->GetSource())
                             {
                                 ChatHandler chatHandle = ChatHandler(playerHandle->GetSession());
-                                chatHandle.PSendSysMessage("|cffFF0000 [-AutoBalance]|r|cffFF8000 %s left %s. Auto setting player count to %u (Player Difficulty Offset = %u) |r", player->GetName().c_str(), map->GetMapName(), mapABInfo->playerCount, PlayerCountDifficultyOffset);
+                                chatHandle.PSendSysMessage("|cffFF0000 [-AutoBalance]|r|cffFF8000 %s left %s. Auto setting player count to %i (Player Difficulty Offset = %i) |r", player->GetName().c_str(), map->GetMapName(), mapABInfo->playerCount + PlayerCountDifficultyOffset, PlayerCountDifficultyOffset);
                             }
                         }
                     }
@@ -760,7 +760,7 @@ public:
         if (!creature->IsAlive())
             return;
 
-        uint32 curCount=mapABInfo->playerCount + PlayerCountDifficultyOffset;
+        int32 curCount=mapABInfo->playerCount + PlayerCountDifficultyOffset;
         if (perDungeonScalingEnabled())
         {
             curCount = adjustCurCount(curCount, mapId);
@@ -1066,7 +1066,7 @@ public:
 
         if (offset)
         {
-            offseti = (uint32)atoi(offset);
+            offseti = (int32)atoi(offset);
             handler->PSendSysMessage("Changing Player Difficulty Offset to %i.", offseti);
             PlayerCountDifficultyOffset = offseti;
             return true;

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -800,7 +800,7 @@ public:
         if (originalLevel <= 1 && areaMinLvl >= 5)
             skipLevel = true;
 
-        if (LevelScaling && creature->GetMap()->IsDungeon() && !skipLevel && !checkLevelOffset(level, originalLevel)) {  // change level only whithin the offsets and when in dungeon/raid
+        if (LevelScaling && (!DungeonsOnly || creature->GetMap()->IsDungeon()) && !skipLevel && !checkLevelOffset(level, originalLevel)) {  // change level only whithin the offsets and when in dungeon/raid
             if (level != creatureABInfo->selectedLevel || creatureABInfo->selectedLevel != creature->getLevel()) {
                 // keep bosses +3 level
                 creatureABInfo->selectedLevel = level + bonusLevel;

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -466,7 +466,8 @@ class AutoBalance_UnitScript : public UnitScript
         damage = _Modifer_DealDamage(target, attacker, damage);
     }
 
-    void ModifyHealRecieved(Unit* target, Unit* attacker, uint32& damage) override {
+    void ModifyHealReceived(Unit* target, Unit* attacker, uint32& damage, SpellInfo const*) override
+    {
         damage = _Modifer_DealDamage(target, attacker, damage);
     }
 

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -385,9 +385,8 @@ class AutoBalance_PlayerScript : public PlayerScript
 
         void OnLogin(Player *Player) override
         {
-            if ((sConfigMgr->GetOption<bool>("AutoBalanceAnnounce.enable", true)) && (sConfigMgr->GetOption<bool>("AutoBalance.enable", true))) {
+            if (enabled && sConfigMgr->GetOption<bool>("AutoBalanceAnnounce.enable", true))
                 ChatHandler(Player->GetSession()).SendSysMessage("This server is running the |cff4CFF00AutoBalance |rmodule.");
-            }
         }
 
         virtual void OnLevelChanged(Player* player, uint8 /*oldlevel*/) override
@@ -406,7 +405,7 @@ class AutoBalance_PlayerScript : public PlayerScript
 
         void OnGiveXP(Player* player, uint32& amount, Unit* victim) override
         {
-            if (victim && DungeonScaleDownXP)
+            if (enabled && victim && DungeonScaleDownXP)
             {
                 Map* map = player->GetMap();
 
@@ -422,7 +421,7 @@ class AutoBalance_PlayerScript : public PlayerScript
 
         void OnBeforeLootMoney(Player* player, Loot* loot) override
         {
-            if (DungeonScaleDownMoney)
+            if (enabled && DungeonScaleDownMoney)
             {
                 Map* map = player->GetMap();
 
@@ -451,7 +450,7 @@ class AutoBalance_UnitScript : public UnitScript
         return _Modifer_DealDamage(playerVictim, AttackerUnit, damage);
     }
 
-    void ModifyPeriodicDamageAurasTick(Unit* target, Unit* attacker, uint32& damage) override
+    void ModifyPeriodicDamageAurasTick(Unit* target, Unit* attacker, uint32& damage, SpellInfo const* /*spellInfo*/) override
     {
         damage = _Modifer_DealDamage(target, attacker, damage);
     }
@@ -1165,7 +1164,11 @@ class AutoBalance_GlobalScript : public GlobalScript {
 public:
     AutoBalance_GlobalScript() : GlobalScript("AutoBalance_GlobalScript") { }
 
-    void OnAfterUpdateEncounterState(Map* map, EncounterCreditType type,  uint32 /*creditEntry*/, Unit* source, Difficulty /*difficulty_fixed*/, DungeonEncounterList const* /*encounters*/, uint32 /*dungeonCompleted*/, bool updated) override {
+    void OnAfterUpdateEncounterState(Map* map, EncounterCreditType type,  uint32 /*creditEntry*/, Unit* source, Difficulty /*difficulty_fixed*/, DungeonEncounterList const* /*encounters*/, uint32 /*dungeonCompleted*/, bool updated) override
+    {
+        if (!enabled)
+            return;
+
         //if (!dungeonCompleted)
         //    return;
 

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -421,7 +421,7 @@ class AutoBalance_PlayerScript : public PlayerScript
                 mapABInfo->mapLevel = player->getLevel();
         }
 
-        void OnGiveXP(Player* player, uint32& amount, Unit* victim) override
+        void OnGiveXP(Player* player, uint32& amount, Unit* victim, uint8 /*xpSource*/) override
         {
             if (enabled && victim && DungeonScaleDownXP)
             {


### PR DESCRIPTION
#
#     AutoBalance.DungeonScaleDownXP
#        Decrease individual player's amount of XP gained during a dungeon to match the
#        amount of XP gained during a full group run. Example: In a 5-man group, you
#        earn 1/5 of the total XP per kill, but if you solo the dungeon with
#        AutoBalance.DungeonScaleDownXP = 0, you will earn 5/5 of the total XP.
#        With the option enabled, you will earn 1/5.
#        Default:     0 (1 = ON, 0 = OFF)

AutoBalance.DungeonScaleDownXP = 1

#
#     AutoBalance.CountNpcBots
#        NPCBots mod integration. Makes bots count as players for player count calculation
#        Default:     1 (1 = ON, 0 = OFF)

AutoBalance.CountNpcBots=1

If countnpcbots is turned on than you got full exp for killing mobs in dungeon. Is it possible to change settings the way you kill instance mobs with bots, but have only 1/5 exp for killing. I know that there's an opportunity to scale xp in npcbots settings, but I'd like to have full exp outside of dungeon.

Можно ли сделать так, чтобы вместе с мобами получать только 1/5 опыта от убийств неписей в данже, но при этом фулл опыт от убийств вне него?

ПС:
#
#     AutoBalance.DungeonsOnly
#        Only apply scaling changes to dungeons and raids
#        Default:     1 (1 = ON, 0 = OFF)

AutoBalance.DungeonsOnly=1

а если здесь 0 поставить, ворлд боссы и элитки в открытом мире будут скалироваться?