### PR TITLE
(features) Add curveFloor and curveCeiling settings, expand raid types, CCDuration, others

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 - Latest build status with azerothcore: [![Build Status](https://github.com/azerothcore/mod-autobalance/workflows/core-build/badge.svg?branch=master&event=push)](https://github.com/azerothcore/mod-autobalance)
 
 This module is intended to scale based on number of players, instance mobs and bosses' health, mana, and damage.
+
+All settings are well-described in the configuration file.
+
+## References
+- [Interactive Inflection Point Spreadsheet](https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/edit?usp=sharing)
+- [InflectionPoint Curve Examples](https://i.imgur.com/x42UnUR.png)
+- [Impact of CurveFloor and CurveCeiling on enemy multiplier](https://i.imgur.com/I8S4cwJ.png)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ This module is intended to scale based on number of players, instance mobs and b
 All settings are well-described in the configuration file.
 
 ## References
-- [Interactive Inflection Point Spreadsheet](https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/edit?usp=sharing)
+- [Interactive Inflection Point Spreadsheet](https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy)
 - [InflectionPoint Curve Examples](https://i.imgur.com/x42UnUR.png)
 - [Impact of CurveFloor and CurveCeiling on enemy multiplier](https://i.imgur.com/I8S4cwJ.png)

--- a/acore-module.json
+++ b/acore-module.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-autobalance",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "compatibility" : [
       { "version": "1.0.0", "branch": "none" },
       { "version": "^2.0.0", "branch": "2.0" },

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -239,60 +239,60 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 ###
 
 ### 10-player raids
-AutoBalance.StatModifierRaid10M.Global=1.0
-AutoBalance.StatModifierRaid10M.Health=1.0
-AutoBalance.StatModifierRaid10M.Mana=1.0
-AutoBalance.StatModifierRaid10M.Armor=1.0
-AutoBalance.StatModifierRaid10M.Damage=1.0
-AutoBalance.StatModifierRaid10M.Boss.Global=1.0
+#AutoBalance.StatModifierRaid10M.Global=1.0
+#AutoBalance.StatModifierRaid10M.Health=1.0
+#AutoBalance.StatModifierRaid10M.Mana=1.0
+#AutoBalance.StatModifierRaid10M.Armor=1.0
+#AutoBalance.StatModifierRaid10M.Damage=1.0
+#AutoBalance.StatModifierRaid10M.Boss.Global=1.0
 
 ### 10-player heroic raids
-AutoBalance.StatModifierRaid10MHeroic.Global=1.0
-AutoBalance.StatModifierRaid10MHeroic.Health=1.0
-AutoBalance.StatModifierRaid10MHeroic.Mana=1.0
-AutoBalance.StatModifierRaid10MHeroic.Armor=1.0
-AutoBalance.StatModifierRaid10MHeroic.Damage=1.0
-AutoBalance.StatModifierRaid10MHeroic.Boss.Global=1.0
+#AutoBalance.StatModifierRaid10MHeroic.Global=1.0
+#AutoBalance.StatModifierRaid10MHeroic.Health=1.0
+#AutoBalance.StatModifierRaid10MHeroic.Mana=1.0
+#AutoBalance.StatModifierRaid10MHeroic.Armor=1.0
+#AutoBalance.StatModifierRaid10MHeroic.Damage=1.0
+#AutoBalance.StatModifierRaid10MHeroic.Boss.Global=1.0
 
 ### 15-player raids
-AutoBalance.StatModifierRaid15M.Global=1.0
-AutoBalance.StatModifierRaid15M.Health=1.0
-AutoBalance.StatModifierRaid15M.Mana=1.0
-AutoBalance.StatModifierRaid15M.Armor=1.0
-AutoBalance.StatModifierRaid15M.Damage=1.0
-AutoBalance.StatModifierRaid15M.Boss.Global=1.0
+#AutoBalance.StatModifierRaid15M.Global=1.0
+#AutoBalance.StatModifierRaid15M.Health=1.0
+#AutoBalance.StatModifierRaid15M.Mana=1.0
+#AutoBalance.StatModifierRaid15M.Armor=1.0
+#AutoBalance.StatModifierRaid15M.Damage=1.0
+#AutoBalance.StatModifierRaid15M.Boss.Global=1.0
 
 ### 20-player raids
-AutoBalance.StatModifierRaid20M.Global=1.0
-AutoBalance.StatModifierRaid20M.Health=1.0
-AutoBalance.StatModifierRaid20M.Mana=1.0
-AutoBalance.StatModifierRaid20M.Armor=1.0
-AutoBalance.StatModifierRaid20M.Damage=1.0
-AutoBalance.StatModifierRaid20M.Boss.Global=1.0
+#AutoBalance.StatModifierRaid20M.Global=1.0
+#AutoBalance.StatModifierRaid20M.Health=1.0
+#AutoBalance.StatModifierRaid20M.Mana=1.0
+#AutoBalance.StatModifierRaid20M.Armor=1.0
+#AutoBalance.StatModifierRaid20M.Damage=1.0
+#AutoBalance.StatModifierRaid20M.Boss.Global=1.0
 
 ### 25-player raids
-AutoBalance.StatModifierRaid25M.Global=1.0
-AutoBalance.StatModifierRaid25M.Health=1.0
-AutoBalance.StatModifierRaid25M.Mana=1.0
-AutoBalance.StatModifierRaid25M.Armor=1.0
-AutoBalance.StatModifierRaid25M.Damage=1.0
-AutoBalance.StatModifierRaid25M.Boss.Global=1.0
+#AutoBalance.StatModifierRaid25M.Global=1.0
+#AutoBalance.StatModifierRaid25M.Health=1.0
+#AutoBalance.StatModifierRaid25M.Mana=1.0
+#AutoBalance.StatModifierRaid25M.Armor=1.0
+#AutoBalance.StatModifierRaid25M.Damage=1.0
+#AutoBalance.StatModifierRaid25M.Boss.Global=1.0
 
 ### 25-player heroic raids
-AutoBalance.StatModifierRaid25MHeroic.Global=1.0
-AutoBalance.StatModifierRaid25MHeroic.Health=1.0
-AutoBalance.StatModifierRaid25MHeroic.Mana=1.0
-AutoBalance.StatModifierRaid25MHeroic.Armor=1.0
-AutoBalance.StatModifierRaid25MHeroic.Damage=1.0
-AutoBalance.StatModifierRaid25MHeroic.Boss.Global=1.0
+#AutoBalance.StatModifierRaid25MHeroic.Global=1.0
+#AutoBalance.StatModifierRaid25MHeroic.Health=1.0
+#AutoBalance.StatModifierRaid25MHeroic.Mana=1.0
+#AutoBalance.StatModifierRaid25MHeroic.Armor=1.0
+#AutoBalance.StatModifierRaid25MHeroic.Damage=1.0
+#AutoBalance.StatModifierRaid25MHeroic.Boss.Global=1.0
 
 ### 40-player raids
-AutoBalance.StatModifierRaid40M.Global=1.0
-AutoBalance.StatModifierRaid40M.Health=1.0
-AutoBalance.StatModifierRaid40M.Mana=1.0
-AutoBalance.StatModifierRaid40M.Armor=1.0
-AutoBalance.StatModifierRaid40M.Damage=1.0
-AutoBalance.StatModifierRaid40M.Boss.Global=1.0
+#AutoBalance.StatModifierRaid40M.Global=1.0
+#AutoBalance.StatModifierRaid40M.Health=1.0
+#AutoBalance.StatModifierRaid40M.Mana=1.0
+#AutoBalance.StatModifierRaid40M.Armor=1.0
+#AutoBalance.StatModifierRaid40M.Damage=1.0
+#AutoBalance.StatModifierRaid40M.Boss.Global=1.0
 
 #
 #     AutoBalance.MinHPModifier

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -295,6 +295,17 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 #AutoBalance.StatModifierRaid40M.Boss.Global=1.0
 
 #
+#     AutoBalance.StatModifierPerDungeon
+#        Allows setting a per-dungeon stat modifier value. If you specify a dungeonID, you MUST specify all the values.
+#
+#        Format: "[dungeonId] [global] [health] [mana] [armor] [damage] [boss], [dungeonId] [global] [health] [mana] [armor] [damage] [boss], ..."
+#
+#        Example: AutoBalance.ModifierPerDungeon="409 1.0 0.8 0.8 1.0 1.2 1.1, 568 1.1 1.0 1.0 1.5 0.8 1.5"
+#
+#        Default: Empty string, which disables the feature.
+AutoBalance.StatModifierPerDungeon=""
+
+#
 #     AutoBalance.MinHPModifier
 #        Minimum Modifier setting for Health Modification. An enemy's health will not be multiplied by a value smaller than this.
 #        Default:     0.01

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -10,7 +10,6 @@
 #     AutoBalanceAnnounce.enable
 #        Announce the module on login if it is enabled
 #        Default:     1 (1 = ON, 0 = OFF)
-
 AutoBalanceAnnounce.enable=1
 
 #
@@ -19,160 +18,168 @@ AutoBalanceAnnounce.enable=1
 #     AutoBalance.enable
 #        Enable/Disable the autobalance system
 #        Default:     1 (1 = ON, 0 = OFF)
-
 AutoBalance.enable=1
 
-#     AutoBalance.InflectionPoint series
-#        Adjust value of Hyperbolic Tangent function where
-#        the curve of scaling must change. A lower value means higher difficulty.
-#        InflectionPoint & InflectionPointHeroic are the fallback values for 5-man dungeons
-#        InflectionPointRaid10M & InflectionPointRaid10MHeroic are the fallback values for 10 man raids
-#        InflectionPointRaid25M & InflectionPointRaid25MHeroic are the fallback values for 25 man raids
-#        InflectionPointRaid & InflectionPointRaidHeroic are the fallback values for other raids (40-man, 20-man, 15-man, or custom size)
-#        The inflection points fallback to the most specific number
+##########################
 #
-#        Example: with 0.5 in InflectionPointRaid, a creature of raid (40) will have half of its life with 20 players in
-#                 with 0.8, the same creature will have half of its life with 12 players in
+# Stat Scaling
 #
-#        Default:     0.5
+##########################
 
+#     AutoBalance.InflectionPoint* series
+#        InflectionPoint
+#           Changes the inflection point of the Hyperbolic Tangent function that determines the enemy multiplier for a given player number.
+#           This adjusts the shape of the overall curve. A lower value means that difficulty will increase faster as you add players.
+#
+#           This image provies a visual of several InflectionPoint settings and its affect on the enemy stat multipliers.
+#           https://i.imgur.com/x42UnUR.png
+#
+#           Example: If InflectionPointRaid is 0.5, an enemy in a 40-player raid will have half its life with 20 players in the instance
+#                    If InflectionPointRaid is 0.8, an enemy in a 40-player raid will have half its life with 12 players in the instance
+#
+#           Default: 0.5
+#
+#        CurveFloor
+#           When the curve to determine the enemy multiplier is calculated, start the curve at this value.
+#
+#           This allows you to make enemies have higher stats for lower player counts without adversely affecting the stats of 
+#           higher player counts. Applied before `AutoBalance.rate.*` values.
+#
+#           To understand how CurveFloor and CurveCeiling affect the multiplier, see this image:
+#           https://i.imgur.com/I8S4cwJ.png
+#
+#           Default: 0.0
+#
+#        CurveCeiling
+#           When the curve to determine the enemy multiplier is calculated, end the curve at this value.
+#
+#           This allows you to make enemies have lower stats for higher player counts without adversely affecting the stats of
+#           lower player counts. Applied before `AutoBalance.rate.*` values.
+#
+#           To understand how CurveFloor and CurveCeiling affect the multiplier, see this image:
+#           https://i.imgur.com/I8S4cwJ.png
+#
+#           May be set to higher than 1.0 to increase difficulty of the instance over the stock values:
+#           https://i.imgur.com/DBPxT8E.png
+#
+#           Default: 1.0
+#
+#       BossModifier
+#           Further adjusts the inflection point of bosses. Only applies to creatures considered dungeon bosses (from dungeons or raids).
+#
+#           To better understand this effect, see the interactive spreadsheet explained below.
+#
+#           Default: 1.0
+#
+#
+#     An interactive spreadsheet is available for you to visually see what effect your settings have on the difficulty curve.
+#
+#     https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/edit?usp=sharing
+#
+#     To use it, copy the sheet to your own Google Drive and edit the values on the left with the yellow background.
+#     The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given dungeon.
+
+### 5-player dungeons
 AutoBalance.InflectionPoint=0.5
+AutoBalance.InflectionPoint.CurveFloor=0.0
+AutoBalance.InflectionPoint.CurveCeiling=1.0
+AutoBalance.InflectionPoint.BossModifier=1.0
+
+### 5-player heroic dungeons
 AutoBalance.InflectionPointHeroic=0.5
+AutoBalance.InflectionPointHeroic.CurveFloor=0.0
+AutoBalance.InflectionPointHeroic.CurveCeiling=1.0
+AutoBalance.InflectionPointHeroic.BossModifier=1.0
 
-AutoBalance.InflectionPointRaid10M=0.5
-AutoBalance.InflectionPointRaid10MHeroic=0.5
-
-AutoBalance.InflectionPointRaid25M=0.5
-AutoBalance.InflectionPointRaid25MHeroic=0.5
-
+### Default for all raids
 AutoBalance.InflectionPointRaid=0.5
+AutoBalance.InflectionPointRaid.CurveFloor=0.0
+AutoBalance.InflectionPointRaid.CurveCeiling=1.0
+AutoBalance.InflectionPointRaid.BossModifier=1.0
+
+### Default for all heroic raids
 AutoBalance.InflectionPointRaidHeroic=0.5
+AutoBalance.InflectionPointRaidHeroic.CurveFloor=0.0
+AutoBalance.InflectionPointRaidHeroic.CurveCeiling=1.0
+AutoBalance.InflectionPointRaidHeroic.BossModifier=1.0
 
+###
+### By default, all instances use the settings configured above. To customize settings for a particular instance size,
+### uncomment the appropriate configuration lines below and adjust values to your liking.
+###
 
-#
-#     AutoBalance.BossInflectionMult
-#        Multiplies the inflection point of bosses, only applies to creatures considered dungeon bosses (from dungeons or raids).
-#        Example: If AutoBalance.BossInflectionMult = 0.4 and AutoBalance.InflectionPoint=0.5, the bosses inflection point will be 0.4*0.9 = 0.36 in a normal dungeon.
-#        Default:     1.0
+### 10-player raids
+#AutoBalance.InflectionPointRaid10M=0.5
+#AutoBalance.InflectionPointRaid10M.CurveFloor=0.0
+#AutoBalance.InflectionPointRaid10M.CurveCeiling=1.0
+#AutoBalance.InflectionPointRaid10M.BossModifier=1.0
 
-AutoBalance.BossInflectionMult=1.0
+### 10-player heroic raids
+#AutoBalance.InflectionPointRaid10MHeroic=0.5
+#AutoBalance.InflectionPointRaid10MHeroic.CurveFloor=0.0
+#AutoBalance.InflectionPointRaid10MHeroic.CurveCeiling=1.0
+#AutoBalance.InflectionPointRaid10MHeroic.BossModifier=1.0
 
-#
-#     AutoBalance.levelScaling
-#        Check the max level of players in map and scale creature based on it.
-#        This triggers depending on the two options below AutoBalance.levelHigherOffset and AutoBalance.levelLowerOffset
-#        0 = Disabled
-#        1 = Enabled (only in dungeons/raids)
-#        Default:     1
+### 15-player raids
+#AutoBalance.InflectionPointRaid15M=0.5
+#AutoBalance.InflectionPointRaid15M.CurveFloor=0.0
+#AutoBalance.InflectionPointRaid15M.CurveCeiling=1.0
+#AutoBalance.InflectionPointRaid15M.BossModifier=1.0
 
-AutoBalance.levelScaling=1
+### 20-player raids
+#AutoBalance.InflectionPointRaid20M=0.5
+#AutoBalance.InflectionPointRaid20M.CurveFloor=0.0
+#AutoBalance.InflectionPointRaid20M.CurveCeiling=1.0
+#AutoBalance.InflectionPointRaid20M.BossModifier=1.0
 
-#
-#     AutoBalance.levelHigherOffset
-#     AutoBalance.levelLowerOffset
-#        Level Offsets between creatures will not be scaled by level.
-#        You can even use it to disable scaling from lower to higher levelScaling
-#        setting levelLowerOffset to 80 (max wotlk level) for example.
-#        default: 3 (higher), 0 (lower)
+### 25-player raids
+#AutoBalance.InflectionPointRaid25M=0.5
+#AutoBalance.InflectionPointRaid25M.CurveFloor=0.0
+#AutoBalance.InflectionPointRaid25M.CurveCeiling=1.0
+#AutoBalance.InflectionPointRaid25M.BossModifier=1.0
 
-AutoBalance.levelHigherOffset = 3
-AutoBalance.levelLowerOffset  = 0
+### 25-player heroic raids
+#AutoBalance.InflectionPointRaid25MHeroic=0.5
+#AutoBalance.InflectionPointRaid25MHeroic.CurveFloor=0.0
+#AutoBalance.InflectionPointRaid25MHeroic.CurveCeiling=1.0
+#AutoBalance.InflectionPointRaid25MHeroic.BossModifier=1.0
 
-#
-#     AutoBalance.levelUseDbValuesWhenExists
-#        When enabled with levelScaling, the creature will use its default database values
-#        instead of level scaling formula when player/party level has correspondance with
-#        creature_template minlevel/maxlevel.
-#
-#        Default:     0 (1 = ON, 0 = OFF)
-
-AutoBalance.levelUseDbValuesWhenExists = 0
-
-#
-#     AutoBalance.LevelEndGameBoost
-#        End game creatures have an exponential (not linear) regression
-#        that is not correctly handled by db values. Keep this enabled
-#        to have stats as near possible to the official ones.
-#
-#        Default:     1 (1 = ON, 0 = OFF)
-
-AutoBalance.LevelEndGameBoost = 1
-
-#
-#     AutoBalance.DungeonScaleDownXP
-#        Decrease individual player's amount of XP gained during a dungeon to match the
-#        amount of XP gained during a full group run. Example: In a 5-man group, you
-#        earn 1/5 of the total XP per kill, but if you solo the dungeon with
-#        AutoBalance.DungeonScaleDownXP = 0, you will earn 5/5 of the total XP.
-#        With the option enabled, you will earn 1/5.
-#        Default:     0 (1 = ON, 0 = OFF)
-
-AutoBalance.DungeonScaleDownXP = 0
+### 40-player raids
+#AutoBalance.InflectionPointRaid40M=0.5
+#AutoBalance.InflectionPointRaid40M.CurveFloor=0.0
+#AutoBalance.InflectionPointRaid40M.CurveCeiling=1.0
+#AutoBalance.InflectionPointRaid40M.BossModifier=1.0
 
 #
-#     AutoBalance.DungeonScaleDownMoney
-#        Decrease individual player's amount of money gained during a dungeon to match the
-#        amount of money gained during a full group run. Example: In a 5-man group, you
-#        earn 1/5 of the total money per kill, but if you solo the dungeon with
-#        AutoBalance.DungeonScaleDownMoney = 0, you will earn 5/5 of the total money.
-#        With the option enabled, you will earn 1/5.
-#        Default:     0 (1 = ON, 0 = OFF)
-
-AutoBalance.DungeonScaleDownMoney = 0
+#     AutoBalance.PerDungeonScaling
+#        Allows setting a per-dungeon or per-raid scaling inflection value
+#        Formatted as "[dungeonId] [inflectionValue], [dungeonId] [inflectionValue], [dungeonId] [inflectionValue], ..."
+#        Example: AutoBalance.PerDungeonScaling="229 0.15, 309 0.3"
+#        For dungeons not listed, the default inflection value provided above for the dungeon's difficulty will be used.
+#        To disable, leave empty. This is the default setting.
+AutoBalance.PerDungeonScaling=""
 
 #
-#     AutoBalance.DungeonsOnly
-#        Only apply scaling changes to dungeons and raids
-#        Default:     1 (1 = ON, 0 = OFF)
+#     AutoBalance.PerDungeonBossScaling
+#        Allows setting a per-dungeon scaling inflection value for bosses
+#        Formatted as "[dungeonId] [inflectionValue], [dungeonId] [inflectionValue], [dungeonId] [inflectionValue], ..."
+#        Example: AutoBalance.PerDungeonBossScaling="229 0.5, 309 1.2, 409 1, 249 1.5"
+#        For dungeons not listed, the default inflection value provided above for the dungeon's difficulty will be used.
+#        To disable, leave empty. This is the default setting.
+AutoBalance.PerDungeonBossScaling=""
 
-AutoBalance.DungeonsOnly=1
-
-#
-#     AutoBalance.DebugLevel
-#        0 = None
-#        1 = Errors Only
-#        2 = Errors and Basic Information
-#        3 = All  Info
-#        Default:     2
-
-AutoBalance.DebugLevel=2
-
-#
-#     .AutoBalance.PlayerChangeNotify
-#        Set Auto Notifications to all players in Instance that player count has changed.
-#        Default:     1 (1 = ON, 0 = OFF)
-
-AutoBalance.PlayerChangeNotify=1
-
-#
-#     AutoBalance.MinHPModifier
-#        Minimum Modifier setting for Health Modification
-#        Default:     0.01
-
-AutoBalance.MinHPModifier=0.01
-
-#
-#     AutoBalance.MinManaModifier
-#        Minimum Modifier setting for Mana Modification
-#        Default:     0.01
-
-AutoBalance.MinManaModifier=0.01
-
-#
-#     AutoBalance.MinDamageModifier
-#        Minimum Modifier setting for Damage Modification
-#        Default:     0.01
-
-AutoBalance.MinDamageModifier=0.01
-
-
-#
 #     AutoBalance.rate.*
-#        You can tune all rates increasing/decreasing difficulty in a linear way
-#        Note that global rate will increase all other rates. For example:
-#        global = 2.0 , damage = 1.5  -> it means that damage will be 3.0
+#        Rate that is applied just before the multiplier is used on enemies. Allows you to linearly shift the curve up or
+#        down to increase or decrease a particualar stat.
+#
+#        Note that global rate will increase all other rates. If global=2.0 and damage=1.5, damage will be multiplied by 3.0.
+#
+#        Example: With AutoBalance.rate.health=1.0, an enemy has 1000 health after scaling.
+#                 With AutoBalance.rate.health=1.5, an enemy has 1500 health after scaling and rate adjustment.
+#
+#        Consult the interactive spreadsheet for more examples.
+#
 #        Default:     1.0
-
 AutoBalance.rate.global = 1.0
 AutoBalance.rate.health = 1.0
 AutoBalance.rate.mana   = 1.0
@@ -180,18 +187,45 @@ AutoBalance.rate.armor  = 1.0
 AutoBalance.rate.damage = 1.0
 
 #
-#     AutoBalance.playerCountDifficultyOffset
-#        Offset of players inside an instance
-#        Default:     0
+#     AutoBalance.MinHPModifier
+#        Minimum Modifier setting for Health Modification. An enemy's health will not be multiplied by a value smaller than this.
+#        Default:     0.01
+AutoBalance.MinHPModifier=0.01
 
+#
+#     AutoBalance.MinManaModifier
+#        Minimum Modifier setting for Mana Modification. An enemy's mana will not be multiplied by a value smaller than this.
+#        Default:     0.01
+AutoBalance.MinManaModifier=0.01
+
+#
+#     AutoBalance.MinDamageModifier
+#        Minimum Modifier setting for Damage Modification. An enemy's damage will not be multiplied by a value smaller than this.
+#        Default:     0.01
+AutoBalance.MinDamageModifier=0.01
+
+#
+#     AutoBalance.playerCountDifficultyOffset
+#        Offset of players inside an instance. Affects all instance types.
+#        Default:     0
 AutoBalance.playerCountDifficultyOffset=0
+
+#
+#     AutoBalance.PerDungeonPlayerCounts
+#        Allows setting a per-dungeon setting for minimum number of players to scale. For example, dungeons could remain at 5 players, but raids could be chosen to scale down to 5 players as well.
+#        Formatted as "[dungeonId] [playerCount], [dungeonId] [playerCount], [dungeonId] [playerCount], ..."
+#        Example: AutoBalance.PerDungeonPlayerCounts="33 1,34 1,36 1,43 1,47 1,48 1,70 1,90 1,109 1,129 1,189 1,209 1,349 1,389 1, 289 2, 329 2, 230 2, 429 2, 309 5, 409 5"
+#        For dungeons not listed, the dungeon's original player count (5, 10, 20, 25, or 40) is used as the minimum, meaning no scaling will take place.
+#        To disable, leave empty; all dungeons will then scale down to 1 player minimum. This is the default setting.
+#        Default: ""
+#
+AutoBalance.PerDungeonPlayerCounts=""
 
 #
 #     AutoBalance.ForcedIDXX
 #        Sets MobIDs for the group they belong to.
 #        All 5 Man Mobs should go in .AutoBalance.5.Name
 #        All 10 Man Mobs should go in .AutoBalance.10.Name etc.
-
 AutoBalance.ForcedID40="11583,16441,30057,13020,15589,14435,18192,14889,14888,14887,14890,15302,15818,15742,15741,15740,18338"
 AutoBalance.ForcedID25="22997,21966,21965,21964,21806,21215,21845,19728,12397,17711,18256,18192,"
 AutoBalance.ForcedID20=""
@@ -203,44 +237,103 @@ AutoBalance.ForcedID2=""
 #     AutoBalance.DisabledID
 #        Disable scaling on specific creatures
 #
-
 AutoBalance.DisabledID=""
 
+##########################
 #
-#     AutoBalance.PerDungeonPlayerCounts
-#        Allows setting a per-dungeon setting for minimum number of players to scale. For example, dungeons could remain at 5 players, but raids could be chosen to scale down to 5 players as well.
-#        Formatted as "[dungeonId] [playerCount], [dungeonId] [playerCount], [dungeonId] [playerCount], ..."
-#        Example: AutoBalance.PerDungeonPlayerCounts="33 1,34 1,36 1,43 1,47 1,48 1,70 1,90 1,109 1,129 1,189 1,209 1,349 1,389 1, 289 2, 329 2, 230 2, 429 2, 309 5, 409 5"
-#        For dungeons not listed, the dungeon's original player count (5, 10, 20, 25, or 40) is used as the minimum, meaning no scaling will take place.
-#        To disable, leave empty; all dungeons will then scale down to 1 player minimum. This is the default setting.
-#        Default: ""
+# Level Scaling
 #
-
-AutoBalance.PerDungeonPlayerCounts=""
+##########################
 
 #
-#     AutoBalance.PerDungeonScaling
-#        Allows setting a per-dungeon scaling inflection value
-#        Formatted as "[dungeonId] [inflectionValue], [dungeonId] [inflectionValue], [dungeonId] [inflectionValue], ..."
-#        Example: AutoBalance.PerDungeonScaling="229 0.15, 309 0.3"
-#        For dungeons not listed, the default inflection value provided above for the dungeon's difficulty will be used.
-#        To disable, leave empty. This is the default setting.
-#        Default: ""
-#
-
-AutoBalance.PerDungeonScaling=""
+#     AutoBalance.levelScaling
+#        Check the max level of players in map and scale creature based on it.
+#        This triggers depending on the two options below AutoBalance.levelHigherOffset and AutoBalance.levelLowerOffset
+#        0 = Disabled
+#        1 = Enabled (only in dungeons/raids)
+#        Default:     1
+AutoBalance.levelScaling=1
 
 #
-#     AutoBalance.PerDungeonBossScaling
-#        Allows setting a per-dungeon scaling inflection value for bosses
-#        Formatted as "[dungeonId] [inflectionValue], [dungeonId] [inflectionValue], [dungeonId] [inflectionValue], ..."
-#        Example: AutoBalance.PerDungeonBossScaling="229 0.5, 309 1.2, 409 1, 249 1.5"
-#        For dungeons not listed, the default inflection value provided above for the dungeon's difficulty will be used.
-#        To disable, leave empty. This is the default setting.
-#        Default: ""
-#
+#     AutoBalance.levelHigherOffset
+#     AutoBalance.levelLowerOffset
+#        Level Offsets between creatures will not be scaled by level.
+#        You can even use it to disable scaling from lower to higher levelScaling
+#        setting levelLowerOffset to 80 (max wotlk level) for example.
+#        default: 3 (higher), 0 (lower)
+AutoBalance.levelHigherOffset = 3
+AutoBalance.levelLowerOffset  = 0
 
-AutoBalance.PerDungeonBossScaling=""
+#
+#     AutoBalance.levelUseDbValuesWhenExists
+#        When enabled with levelScaling, the creature will use its default database values
+#        instead of level scaling formula when player/party level has correspondance with
+#        creature_template minlevel/maxlevel.
+#
+#        Default:     0 (1 = ON, 0 = OFF)
+AutoBalance.levelUseDbValuesWhenExists = 0
+
+#
+#     AutoBalance.LevelEndGameBoost
+#        End game creatures have an exponential (not linear) regression
+#        that is not correctly handled by db values. Keep this enabled
+#        to have stats as near possible to the official ones.
+#
+#        Default:     1 (1 = ON, 0 = OFF)
+AutoBalance.LevelEndGameBoost = 1
+
+##########################
+#
+# Reward Scaling
+#
+##########################
+
+#
+#     AutoBalance.DungeonScaleDownXP
+#        Decrease individual player's amount of XP gained during a dungeon to match the
+#        amount of XP gained during a full group run. Example: In a 5-man group, you
+#        earn 1/5 of the total XP per kill, but if you solo the dungeon with
+#        AutoBalance.DungeonScaleDownXP = 0, you will earn 5/5 of the total XP.
+#        With the option enabled, you will earn 1/5.
+#        Default:     0 (1 = ON, 0 = OFF)
+AutoBalance.DungeonScaleDownXP = 0
+
+#
+#     AutoBalance.DungeonScaleDownMoney
+#        Decrease individual player's amount of money gained during a dungeon to match the
+#        amount of money gained during a full group run. Example: In a 5-man group, you
+#        earn 1/5 of the total money per kill, but if you solo the dungeon with
+#        AutoBalance.DungeonScaleDownMoney = 0, you will earn 5/5 of the total money.
+#        With the option enabled, you will earn 1/5.
+#        Default:     0 (1 = ON, 0 = OFF)
+AutoBalance.DungeonScaleDownMoney = 0
+
+#
+#     AutoBalance.DungeonsOnly
+#        Only apply scaling changes to dungeons and raids
+#        Default:     1 (1 = ON, 0 = OFF)
+AutoBalance.DungeonsOnly=1
+
+##########################
+#
+# Messages
+#
+##########################
+
+#
+#     AutoBalance.DebugLevel
+#        0 = None
+#        1 = Errors Only
+#        2 = Errors and Basic Information
+#        3 = All  Info
+#        Default:     2
+AutoBalance.DebugLevel=2
+
+#
+#     .AutoBalance.PlayerChangeNotify
+#        Set Auto Notifications to all players in Instance that player count has changed.
+#        Default:     1 (1 = ON, 0 = OFF)
+AutoBalance.PlayerChangeNotify=1
 
 ##########################
 #
@@ -256,7 +349,6 @@ AutoBalance.PerDungeonBossScaling=""
 #       This is an idea to boost old contents even if you're end-game player.
 #
 #       Default:     0 (1 = ON, 0 = OFF)
-
 AutoBalance.reward.enable = 0
 
 
@@ -268,7 +360,6 @@ AutoBalance.reward.enable = 0
 #       Default:
 #           raidToken -> emblem of frost (49426)
 #           dungeonToken -> emblem of triumph (47241)
-
 AutoBalance.reward.raidToken    = 49426
 AutoBalance.reward.dungeonToken = 47241
 
@@ -280,6 +371,5 @@ AutoBalance.reward.dungeonToken = 47241
 #		this will give more a challenge to players for low level instances.
 #
 #       Default:     1
-
 AutoBalance.reward.MinPlayerReward = 1
-#
+

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -296,11 +296,12 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 
 #
 #     AutoBalance.StatModifierPerDungeon
-#        Allows setting a per-dungeon stat modifier value. If you specify a dungeonID, you MUST specify all the values.
+#        Allows setting a per-dungeon stat modifier value. Specifying a value of `-1` will use the instance-level settings for that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per dungeonId.
 #
-#        Format: "[dungeonId] [global] [health] [mana] [armor] [damage] [boss], [dungeonId] [global] [health] [mana] [armor] [damage] [boss], ..."
+#        Format: "[dungeonId] [global] [health] [mana] [armor] [damage] [boss.global], [dungeonId] [global] [health] [mana] [armor] [damage] [boss.global], ..."
 #
-#        Example: AutoBalance.ModifierPerDungeon="409 1.0 0.8 0.8 1.0 1.2 1.1, 568 1.1 1.0 1.0 1.5 0.8 1.5"
+#        Example: AutoBalance.ModifierPerDungeon="409 1.0 0.8 0.8 1.0 1.2 1.1, 568 -1 -1 -1 -1 -1 1.5, 43 -1 1.2 1.2"
 #
 #        Default: Empty string, which disables the feature.
 AutoBalance.StatModifierPerDungeon=""

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -144,7 +144,7 @@ AutoBalance.InflectionPointRaid25M.CurveCeiling=
 AutoBalance.InflectionPointRaid25M.BossModifier=
 
 ### 25-player heroic raids
-AutoBalance.InflectionPointRaid25MHeroic=0.5
+AutoBalance.InflectionPointRaid25MHeroic=
 AutoBalance.InflectionPointRaid25MHeroic.CurveFloor=
 AutoBalance.InflectionPointRaid25MHeroic.CurveCeiling=
 AutoBalance.InflectionPointRaid25MHeroic.BossModifier=
@@ -389,6 +389,98 @@ AutoBalance.StatModifierRaid40M.Boss.Mana=
 AutoBalance.StatModifierRaid40M.Boss.Armor=
 AutoBalance.StatModifierRaid40M.Boss.Damage=
 
+#     AutoBalance.StatModifier*.CCDuration series
+#        These StatModifier values affect the duration of CC effects used against the players. CC effects are auras with one
+#        or more of these effects:
+#
+#          - SPELL_AURA_MOD_CHARM
+#          - SPELL_AURA_MOD_CONFUSE
+#          - SPELL_AURA_MOD_DISARM
+#          - SPELL_AURA_MOD_FEAR
+#          - SPELL_AURA_MOD_PACIFY
+#          - SPELL_AURA_MOD_POSSESS
+#          - SPELL_AURA_MOD_SILENCE
+#          - SPELL_AURA_MOD_STUN
+#          - SPELL_AURA_MOD_SPEED_SLOW_ALL
+#
+#        CCDuration
+#           Adjusts the duration of CC effects. Not affected by any global settings.
+#
+#           After the InflectionPoint curve determines the base multiplier, it is multiplied by this value to determine the final
+#           CC duration multiplier.
+#
+#           CCDuration IS affected by the InflectionPoint curve!
+#           CCDuration IS NOT affected by StatModifier*.Global values!
+#           CCDuration IS affected by AutoBalance.MinCCDurationModifier and AutoBalance.MaxCCDurationModifier!
+#
+#           Example:
+#               Assume we are using the default InflectionPoint curve (0.5 with 0.0 floor and 1.0 ceiling), and there are 3 players in the instance.
+#               With 3 players, the base multiplier is '0.6843'. Let's say that CCDuration is set to '0.5'.
+#               The final CC Duration multiplier is 0.6843 * 0.5 = 0.34215
+#               For a CC with a programmed duration of 8 seconds, the CC will last 8 * 0.34215 = 2.7372 seconds.
+#
+#           Default: no value
+#               If no value is set for a given instance type and player count, and the generic values that apply to that instance
+#               are also blank, CC duration will be unchanged.
+#
+#        Boss.Global | Boss.Health | Boss.Mana | Boss.Armor | Boss.Damage
+#           Sets a SEPARATE stat multiplier for bosses. Is NOT affected by the non-boss modifiers. Only applies to creatures
+#           considered instance bosses (from dungeons or raids).
+#
+#           Default: If not set for a given instance size/type, defaults to the dungeon/raid default values.
+#
+#           To better understand this effect, see the interactive spreadsheet.
+#
+
+### 5-player dungeons
+AutoBalance.StatModifier.CCDuration=
+AutoBalance.StatModifier.Boss.CCDuration=
+
+### 5-player heroic dungeons
+AutoBalance.StatModifierHeroic.CCDuration=
+AutoBalance.StatModifierHeroic.Boss.CCDuration=
+
+### Default for all raids
+AutoBalance.StatModifierRaid.CCDuration=
+AutoBalance.StatModifierRaid.Boss.CCDuration=
+
+### Default for all heroic raids
+AutoBalance.StatModifierRaidHeroic.CCDuration=
+AutoBalance.StatModifierRaidHeroic.Boss.CCDuration=
+
+###
+### Configuring the CCDuration settings above this line will affect all dungeons and raids.
+### To customize settings for a particular instance size, add your value to the settings below.
+###
+
+### 10-player raids
+AutoBalance.StatModifierRaid10M.CCDuration=
+AutoBalance.StatModifierRaid10M.Boss.CCDuration=
+
+### 10-player heroic raids
+AutoBalance.StatModifierRaid10MHeroic.CCDuration=
+AutoBalance.StatModifierRaid10MHeroic.Boss.CCDuration=
+
+### 15-player raids
+AutoBalance.StatModifierRaid15M.CCDuration=
+AutoBalance.StatModifierRaid15M.Boss.CCDuration=
+
+### 20-player raids
+AutoBalance.StatModifierRaid20M.CCDuration=
+AutoBalance.StatModifierRaid20M.Boss.CCDuration=
+
+### 25-player raids
+AutoBalance.StatModifierRaid25M.CCDuration=
+AutoBalance.StatModifierRaid25M.Boss.CCDuration=
+
+### 25-player heroic raids
+AutoBalance.StatModifierRaid25MHeroic.CCDuration=
+AutoBalance.StatModifierRaid25MHeroic.Boss.CCDuration=
+
+### 40-player raids
+AutoBalance.StatModifierRaid40M.CCDuration=
+AutoBalance.StatModifierRaid40M.Boss.CCDuration=
+
 ##########################
 #
 # Stat Scaling - Stat Modifier Overrides
@@ -432,9 +524,9 @@ AutoBalance.StatModifierRaid40M.Boss.Damage=
 #
 #        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
 #
-#        Format: "[InstanceID] [Global] [Health] [Mana] [Armor] [Damage], [InstanceID] [Global] [Health] [Mana] [Armor] [Damage], ..."
+#        Format: "[InstanceID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], [InstanceID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], ..."
 #
-#        Example: AutoBalance.StatModifier.PerInstance="409 1.0 0.8 0.8 1.0 1.2, 568 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#        Example: AutoBalance.StatModifier.PerInstance="409 1.0 0.8 0.8 1.0 1.2 1.0, 568 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
 #
 #        Default: Empty string, which disables the feature.
 AutoBalance.StatModifier.PerInstance=""
@@ -448,9 +540,9 @@ AutoBalance.StatModifier.PerInstance=""
 #
 #        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
 #
-#        Format: "[InstanceID] [Boss.Global] [Boss.Health] [Boss.Mana] [Boss.Armor] [Boss.Damage], [InstanceID] [Boss.Global] [Boss.Health] [Boss.Mana] [Boss.Armor] [Boss.Damage], ..."
+#        Format: "[InstanceID] [Boss.Global] [Boss.Health] [Boss.Mana] [Boss.Armor] [Boss.Damage] [Boss.CCDuration], [InstanceID] [Boss.Global] [Boss.Health] [Boss.Mana] [Boss.Armor] [Boss.Damage] [Boss.CCDuration], ..."
 #
-#        Example: AutoBalance.StatModifier.Boss.PerInstance="409 1.0 0.8 0.8 1.0 1.2, 568 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#        Example: AutoBalance.StatModifier.Boss.PerInstance="409 1.0 0.8 0.8 1.0 1.2 0.8, 568 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
 #
 #        Default: Empty string, which disables the feature.
 AutoBalance.StatModifier.Boss.PerInstance=""
@@ -460,9 +552,9 @@ AutoBalance.StatModifier.Boss.PerInstance=""
 #        Allows setting per-creature stat modifier values. Specifying a value of `-1` will skip overriding of that value.
 #        You may omit entries from the end of the string if desired. Only one set of values should be specified per CreatureID.
 #
-#        Format: "[CreatureID] [Global] [Health] [Mana] [Armor] [Damage], [CreatureID] [Global] [Health] [Mana] [Armor] [Damage], ..."
+#        Format: "[CreatureID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], [CreatureID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], ..."
 #
-#        Example: AutoBalance.StatModifier.Boss.PerInstance="14507 1.0 0.8 0.8 1.0 1.2, 11372 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#        Example: AutoBalance.StatModifier.Boss.PerInstance="14507 1.0 0.8 0.8 1.0 1.2 0.5, 11372 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
 #
 #        Default: Empty string, which disables the feature.
 AutoBalance.StatModifier.PerCreature=""
@@ -484,6 +576,18 @@ AutoBalance.MinManaModifier=0.01
 #        Minimum Modifier setting for Damage Modification. An enemy's damage will not be multiplied by a value smaller than this.
 #        Default:     0.01
 AutoBalance.MinDamageModifier=0.01
+
+#
+#     AutoBalance.MinCCDurationModifier
+#        Minimum Modifier setting for Crowd Control Duration. The duration of an enemy's CC will not be multiplied by a value smaller than this.
+#        Default:     0.25
+AutoBalance.MinCCDurationModifier=0.25
+
+#
+#     AutoBalance.MaxCCDurationModifier
+#        Maximum Modifier setting for Crowd Control Duration. The duration of an enemy's CC will not be multiplied by a value greater than this.
+#        Default:     1.0
+AutoBalance.MaxCCDurationModifier=1.0
 
 ##########################
 #

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -43,7 +43,7 @@ AutoBalance.enable=1
 #           When the curve to determine the enemy multiplier is calculated, start the curve at this value.
 #
 #           This allows you to make enemies have higher stats for lower player counts without adversely affecting the stats of 
-#           higher player counts. Applied before `AutoBalance.rate.*` values.
+#           higher player counts. Applied before `AutoBalance.StatModifier.*` values.
 #
 #           To understand how CurveFloor and CurveCeiling affect the multiplier, see this image:
 #           https://i.imgur.com/I8S4cwJ.png
@@ -54,7 +54,7 @@ AutoBalance.enable=1
 #           When the curve to determine the enemy multiplier is calculated, end the curve at this value.
 #
 #           This allows you to make enemies have lower stats for higher player counts without adversely affecting the stats of
-#           lower player counts. Applied before `AutoBalance.rate.*` values.
+#           lower player counts. Applied before `AutoBalance.StatModifier.*` values.
 #
 #           To understand how CurveFloor and CurveCeiling affect the multiplier, see this image:
 #           https://i.imgur.com/I8S4cwJ.png

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -108,51 +108,52 @@ AutoBalance.InflectionPointRaidHeroic.CurveCeiling=1.0
 AutoBalance.InflectionPointRaidHeroic.BossModifier=1.0
 
 ###
-### By default, all instances use the settings configured above. To customize settings for a particular instance size,
-### uncomment the appropriate configuration lines below and adjust values to your liking.
+### By default, all instances use the settings configured above. To customize settings for 
+### a particular instance size or difficulty, set the variables below. If the variable is 
+### blank, the broader settings above will apply.
 ###
 
 ### 10-player raids
-#AutoBalance.InflectionPointRaid10M=0.5
-#AutoBalance.InflectionPointRaid10M.CurveFloor=0.0
-#AutoBalance.InflectionPointRaid10M.CurveCeiling=1.0
-#AutoBalance.InflectionPointRaid10M.BossModifier=1.0
+AutoBalance.InflectionPointRaid10M=
+AutoBalance.InflectionPointRaid10M.CurveFloor=
+AutoBalance.InflectionPointRaid10M.CurveCeiling=
+AutoBalance.InflectionPointRaid10M.BossModifier=
 
 ### 10-player heroic raids
-#AutoBalance.InflectionPointRaid10MHeroic=0.5
-#AutoBalance.InflectionPointRaid10MHeroic.CurveFloor=0.0
-#AutoBalance.InflectionPointRaid10MHeroic.CurveCeiling=1.0
-#AutoBalance.InflectionPointRaid10MHeroic.BossModifier=1.0
+AutoBalance.InflectionPointRaid10MHeroic=
+AutoBalance.InflectionPointRaid10MHeroic.CurveFloor=
+AutoBalance.InflectionPointRaid10MHeroic.CurveCeiling=
+AutoBalance.InflectionPointRaid10MHeroic.BossModifier=
 
 ### 15-player raids
-#AutoBalance.InflectionPointRaid15M=0.5
-#AutoBalance.InflectionPointRaid15M.CurveFloor=0.0
-#AutoBalance.InflectionPointRaid15M.CurveCeiling=1.0
-#AutoBalance.InflectionPointRaid15M.BossModifier=1.0
+AutoBalance.InflectionPointRaid15M=
+AutoBalance.InflectionPointRaid15M.CurveFloor=
+AutoBalance.InflectionPointRaid15M.CurveCeiling=
+AutoBalance.InflectionPointRaid15M.BossModifier=
 
 ### 20-player raids
-#AutoBalance.InflectionPointRaid20M=0.5
-#AutoBalance.InflectionPointRaid20M.CurveFloor=0.0
-#AutoBalance.InflectionPointRaid20M.CurveCeiling=1.0
-#AutoBalance.InflectionPointRaid20M.BossModifier=1.0
+AutoBalance.InflectionPointRaid20M=
+AutoBalance.InflectionPointRaid20M.CurveFloor=
+AutoBalance.InflectionPointRaid20M.CurveCeiling=
+AutoBalance.InflectionPointRaid20M.BossModifier=
 
 ### 25-player raids
-#AutoBalance.InflectionPointRaid25M=0.5
-#AutoBalance.InflectionPointRaid25M.CurveFloor=0.0
-#AutoBalance.InflectionPointRaid25M.CurveCeiling=1.0
-#AutoBalance.InflectionPointRaid25M.BossModifier=1.0
+AutoBalance.InflectionPointRaid25M=
+AutoBalance.InflectionPointRaid25M.CurveFloor=
+AutoBalance.InflectionPointRaid25M.CurveCeiling=
+AutoBalance.InflectionPointRaid25M.BossModifier=
 
 ### 25-player heroic raids
-#AutoBalance.InflectionPointRaid25MHeroic=0.5
-#AutoBalance.InflectionPointRaid25MHeroic.CurveFloor=0.0
-#AutoBalance.InflectionPointRaid25MHeroic.CurveCeiling=1.0
-#AutoBalance.InflectionPointRaid25MHeroic.BossModifier=1.0
+AutoBalance.InflectionPointRaid25MHeroic=0.5
+AutoBalance.InflectionPointRaid25MHeroic.CurveFloor=
+AutoBalance.InflectionPointRaid25MHeroic.CurveCeiling=
+AutoBalance.InflectionPointRaid25MHeroic.BossModifier=
 
 ### 40-player raids
-#AutoBalance.InflectionPointRaid40M=0.5
-#AutoBalance.InflectionPointRaid40M.CurveFloor=0.0
-#AutoBalance.InflectionPointRaid40M.CurveCeiling=1.0
-#AutoBalance.InflectionPointRaid40M.BossModifier=1.0
+AutoBalance.InflectionPointRaid40M=
+AutoBalance.InflectionPointRaid40M.CurveFloor=
+AutoBalance.InflectionPointRaid40M.CurveCeiling=
+AutoBalance.InflectionPointRaid40M.BossModifier=
 
 #
 #     AutoBalance.InflectionPoint.PerInstance
@@ -292,100 +293,101 @@ AutoBalance.StatModifierRaidHeroic.Boss.Armor=1.0
 AutoBalance.StatModifierRaidHeroic.Boss.Damage=1.0
 
 ###
-### By default, all instances use the settings configured above. To customize settings for a particular instance size,
-### uncomment the appropriate configuration lines below and adjust values to your liking.
+### By default, all instances use the settings configured above. To customize settings for 
+### a particular instance size or difficulty, set the variables below. If the variable is 
+### blank, the broader settings above will apply.
 ###
 
 ### 10-player raids
-#AutoBalance.StatModifierRaid10M.Global=1.0
-#AutoBalance.StatModifierRaid10M.Health=1.0
-#AutoBalance.StatModifierRaid10M.Mana=1.0
-#AutoBalance.StatModifierRaid10M.Armor=1.0
-#AutoBalance.StatModifierRaid10M.Damage=1.0
+AutoBalance.StatModifierRaid10M.Global=
+AutoBalance.StatModifierRaid10M.Health=
+AutoBalance.StatModifierRaid10M.Mana=
+AutoBalance.StatModifierRaid10M.Armor=
+AutoBalance.StatModifierRaid10M.Damage=
 
-#AutoBalance.StatModifierRaid10M.Boss.Global=1.0
-#AutoBalance.StatModifierRaid10M.Boss.Health=1.0
-#AutoBalance.StatModifierRaid10M.Boss.Mana=1.0
-#AutoBalance.StatModifierRaid10M.Boss.Armor=1.0
-#AutoBalance.StatModifierRaid10M.Boss.Damage=1.0
+AutoBalance.StatModifierRaid10M.Boss.Global=
+AutoBalance.StatModifierRaid10M.Boss.Health=
+AutoBalance.StatModifierRaid10M.Boss.Mana=
+AutoBalance.StatModifierRaid10M.Boss.Armor=
+AutoBalance.StatModifierRaid10M.Boss.Damage=
 
 ### 10-player heroic raids
-#AutoBalance.StatModifierRaid10MHeroic.Global=1.0
-#AutoBalance.StatModifierRaid10MHeroic.Health=1.0
-#AutoBalance.StatModifierRaid10MHeroic.Mana=1.0
-#AutoBalance.StatModifierRaid10MHeroic.Armor=1.0
-#AutoBalance.StatModifierRaid10MHeroic.Damage=1.0
+AutoBalance.StatModifierRaid10MHeroic.Global=
+AutoBalance.StatModifierRaid10MHeroic.Health=
+AutoBalance.StatModifierRaid10MHeroic.Mana=
+AutoBalance.StatModifierRaid10MHeroic.Armor=
+AutoBalance.StatModifierRaid10MHeroic.Damage=
 
-#AutoBalance.StatModifierRaid10MHeroic.Boss.Global=1.0
-#AutoBalance.StatModifierRaid10MHeroic.Boss.Health=1.0
-#AutoBalance.StatModifierRaid10MHeroic.Boss.Mana=1.0
-#AutoBalance.StatModifierRaid10MHeroic.Boss.Armor=1.0
-#AutoBalance.StatModifierRaid10MHeroic.Boss.Damage=1.0
+AutoBalance.StatModifierRaid10MHeroic.Boss.Global=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Health=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Mana=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Armor=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Damage=
 
 ### 15-player raids
-#AutoBalance.StatModifierRaid15M.Global=1.0
-#AutoBalance.StatModifierRaid15M.Health=1.0
-#AutoBalance.StatModifierRaid15M.Mana=1.0
-#AutoBalance.StatModifierRaid15M.Armor=1.0
-#AutoBalance.StatModifierRaid15M.Damage=1.0
+AutoBalance.StatModifierRaid15M.Global=
+AutoBalance.StatModifierRaid15M.Health=
+AutoBalance.StatModifierRaid15M.Mana=
+AutoBalance.StatModifierRaid15M.Armor=
+AutoBalance.StatModifierRaid15M.Damage=
 
-#AutoBalance.StatModifierRaid15M.Boss.Global=1.0
-#AutoBalance.StatModifierRaid15M.Boss.Health=1.0
-#AutoBalance.StatModifierRaid15M.Boss.Mana=1.0
-#AutoBalance.StatModifierRaid15M.Boss.Armor=1.0
-#AutoBalance.StatModifierRaid15M.Boss.Damage=1.0
+AutoBalance.StatModifierRaid15M.Boss.Global=
+AutoBalance.StatModifierRaid15M.Boss.Health=
+AutoBalance.StatModifierRaid15M.Boss.Mana=
+AutoBalance.StatModifierRaid15M.Boss.Armor=
+AutoBalance.StatModifierRaid15M.Boss.Damage=
 
 ### 20-player raids
-#AutoBalance.StatModifierRaid20M.Global=1.0
-#AutoBalance.StatModifierRaid20M.Health=1.0
-#AutoBalance.StatModifierRaid20M.Mana=1.0
-#AutoBalance.StatModifierRaid20M.Armor=1.0
-#AutoBalance.StatModifierRaid20M.Damage=1.0
+AutoBalance.StatModifierRaid20M.Global=
+AutoBalance.StatModifierRaid20M.Health=
+AutoBalance.StatModifierRaid20M.Mana=
+AutoBalance.StatModifierRaid20M.Armor=
+AutoBalance.StatModifierRaid20M.Damage=
 
-#AutoBalance.StatModifierRaid20M.Boss.Global=1.0
-#AutoBalance.StatModifierRaid20M.Boss.Health=1.0
-#AutoBalance.StatModifierRaid20M.Boss.Mana=1.0
-#AutoBalance.StatModifierRaid20M.Boss.Armor=1.0
-#AutoBalance.StatModifierRaid20M.Boss.Damage=1.0
+AutoBalance.StatModifierRaid20M.Boss.Global=
+AutoBalance.StatModifierRaid20M.Boss.Health=
+AutoBalance.StatModifierRaid20M.Boss.Mana=
+AutoBalance.StatModifierRaid20M.Boss.Armor=
+AutoBalance.StatModifierRaid20M.Boss.Damage=
 
 ### 25-player raids
-#AutoBalance.StatModifierRaid25M.Global=1.0
-#AutoBalance.StatModifierRaid25M.Health=1.0
-#AutoBalance.StatModifierRaid25M.Mana=1.0
-#AutoBalance.StatModifierRaid25M.Armor=1.0
-#AutoBalance.StatModifierRaid25M.Damage=1.0
+AutoBalance.StatModifierRaid25M.Global=
+AutoBalance.StatModifierRaid25M.Health=
+AutoBalance.StatModifierRaid25M.Mana=
+AutoBalance.StatModifierRaid25M.Armor=
+AutoBalance.StatModifierRaid25M.Damage=
 
-#AutoBalance.StatModifierRaid25M.Boss.Global=1.0
-#AutoBalance.StatModifierRaid25M.Boss.Health=1.0
-#AutoBalance.StatModifierRaid25M.Boss.Mana=1.0
-#AutoBalance.StatModifierRaid25M.Boss.Armor=1.0
-#AutoBalance.StatModifierRaid25M.Boss.Damage=1.0
+AutoBalance.StatModifierRaid25M.Boss.Global=
+AutoBalance.StatModifierRaid25M.Boss.Health=
+AutoBalance.StatModifierRaid25M.Boss.Mana=
+AutoBalance.StatModifierRaid25M.Boss.Armor=
+AutoBalance.StatModifierRaid25M.Boss.Damage=
 
 ### 25-player heroic raids
-#AutoBalance.StatModifierRaid25MHeroic.Global=1.0
-#AutoBalance.StatModifierRaid25MHeroic.Health=1.0
-#AutoBalance.StatModifierRaid25MHeroic.Mana=1.0
-#AutoBalance.StatModifierRaid25MHeroic.Armor=1.0
-#AutoBalance.StatModifierRaid25MHeroic.Damage=1.0
+AutoBalance.StatModifierRaid25MHeroic.Global=
+AutoBalance.StatModifierRaid25MHeroic.Health=
+AutoBalance.StatModifierRaid25MHeroic.Mana=
+AutoBalance.StatModifierRaid25MHeroic.Armor=
+AutoBalance.StatModifierRaid25MHeroic.Damage=
 
-#AutoBalance.StatModifierRaid25MHeroic.Boss.Global=1.0
-#AutoBalance.StatModifierRaid25MHeroic.Boss.Health=1.0
-#AutoBalance.StatModifierRaid25MHeroic.Boss.Mana=1.0
-#AutoBalance.StatModifierRaid25MHeroic.Boss.Armor=1.0
-#AutoBalance.StatModifierRaid25MHeroic.Boss.Damage=1.0
+AutoBalance.StatModifierRaid25MHeroic.Boss.Global=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Health=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Mana=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Armor=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Damage=
 
 ### 40-player raids
-#AutoBalance.StatModifierRaid40M.Global=1.0
-#AutoBalance.StatModifierRaid40M.Health=1.0
-#AutoBalance.StatModifierRaid40M.Mana=1.0
-#AutoBalance.StatModifierRaid40M.Armor=1.0
-#AutoBalance.StatModifierRaid40M.Damage=1.0
+AutoBalance.StatModifierRaid40M.Global=
+AutoBalance.StatModifierRaid40M.Health=
+AutoBalance.StatModifierRaid40M.Mana=
+AutoBalance.StatModifierRaid40M.Armor=
+AutoBalance.StatModifierRaid40M.Damage=
 
-#AutoBalance.StatModifierRaid40M.Boss.Global=1.0
-#AutoBalance.StatModifierRaid40M.Boss.Health=1.0
-#AutoBalance.StatModifierRaid40M.Boss.Mana=1.0
-#AutoBalance.StatModifierRaid40M.Boss.Armor=1.0
-#AutoBalance.StatModifierRaid40M.Boss.Damage=1.0
+AutoBalance.StatModifierRaid40M.Boss.Global=
+AutoBalance.StatModifierRaid40M.Boss.Health=
+AutoBalance.StatModifierRaid40M.Boss.Mana=
+AutoBalance.StatModifierRaid40M.Boss.Armor=
+AutoBalance.StatModifierRaid40M.Boss.Damage=
 
 ##########################
 #

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -35,7 +35,7 @@ AutoBalance.enable=1
 #           https://i.imgur.com/x42UnUR.png
 #
 #           Example: If InflectionPointRaid is 0.5, an enemy in a 40-player raid will have half its life with 20 players in the instance
-#                    If InflectionPointRaid is 0.8, an enemy in a 40-player raid will have half its life with 12 players in the instance
+#                    If InflectionPointRaid is 0.8, an enemy in a 40-player raid will have half its life with 31 players in the instance
 #
 #           Default: 0.5
 #

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -202,12 +202,12 @@ AutoBalance.PerDungeonBossScaling=""
 
 
 ### 5-player dungeons
-AutoBalance.StatModifier.Global=0.5
+AutoBalance.StatModifier.Global=1.0
 AutoBalance.StatModifier.Health=1.0
 AutoBalance.StatModifier.Mana=1.0
 AutoBalance.StatModifier.Armor=1.0
 AutoBalance.StatModifier.Damage=1.0
-AutoBalance.StatModifier.Boss.Global=1.5
+AutoBalance.StatModifier.Boss.Global=1.0
 
 ### 5-player heroic dungeons
 AutoBalance.StatModifierHeroic.Global=1.0
@@ -345,7 +345,7 @@ AutoBalance.ForcedID2=""
 #     AutoBalance.DisabledID
 #        Disable scaling on specific creatures
 #
-AutoBalance.DisabledID=""
+AutoBalance.DisabledID="6867"
 
 ##########################
 #

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -22,20 +22,20 @@ AutoBalance.enable=1
 
 ##########################
 #
-# Stat Scaling
+# Stat Scaling - Inflection Point
 #
 ##########################
 
 #     AutoBalance.InflectionPoint* series
 #        InflectionPoint
-#           Changes the inflection point of the Hyperbolic Tangent function that determines the enemy multiplier for a given player number.
+#           Changes the inflection point of the Hyperbolic Tangent function that determines the enemy multiplier for a given player count.
 #           This adjusts the shape of the overall curve. A lower value means that difficulty will increase faster as you add players.
 #
 #           This image provies a visual of several InflectionPoint settings and its affect on the enemy stat multipliers.
 #           https://i.imgur.com/x42UnUR.png
 #
-#           Example: If InflectionPointRaid is 0.5, an enemy in a 40-player raid will have half its life with 20 players in the instance
-#                    If InflectionPointRaid is 0.8, an enemy in a 40-player raid will have half its life with 31 players in the instance
+#           Example: If InflectionPointRaid is 0.5, an enemy in a 40-player instance will have half its life with 20 players in the instance
+#                    If InflectionPointRaid is 0.8, an enemy in a 40-player instance will have half its life with 12 players in the instance
 #
 #           Default: 0.5
 #
@@ -43,7 +43,9 @@ AutoBalance.enable=1
 #           When the curve to determine the enemy multiplier is calculated, start the curve at this value.
 #
 #           This allows you to make enemies have higher stats for lower player counts without adversely affecting the stats of 
-#           higher player counts. Applied before `AutoBalance.StatModifier.*` values.
+#           higher player counts. Applied before `AutoBalance.StatModifier*` values.
+#
+#           Value may be negative if needed to achieve your desired curve.
 #
 #           To understand how CurveFloor and CurveCeiling affect the multiplier, see this image:
 #           https://i.imgur.com/I8S4cwJ.png
@@ -54,7 +56,7 @@ AutoBalance.enable=1
 #           When the curve to determine the enemy multiplier is calculated, end the curve at this value.
 #
 #           This allows you to make enemies have lower stats for higher player counts without adversely affecting the stats of
-#           lower player counts. Applied before `AutoBalance.StatModifier.*` values.
+#           lower player counts. Applied before `AutoBalance.StatModifier*` values.
 #
 #           To understand how CurveFloor and CurveCeiling affect the multiplier, see this image:
 #           https://i.imgur.com/I8S4cwJ.png
@@ -188,11 +190,25 @@ AutoBalance.InflectionPoint.PerInstance=""
 #
 AutoBalance.InflectionPoint.Boss.PerInstance=""
 
+#
+#     AutoBalance.playerCountDifficultyOffset
+#        Offset of players inside an instance. Affects all instance types.
+#        Default:     0
+AutoBalance.playerCountDifficultyOffset=0
+
+##########################
+#
+# Stat Scaling - Stat Modifiers
+#
+##########################
 
 #     AutoBalance.StatModifier* series
 #        The difficulty curve (as defined by the InflectionPoint settings) determines the base multiplier. The base
 #        multiplier is then adjusted (multiplied) by the appropriate StatModifier setting. This allows you to control
 #        the balance of how scaling affects the four adjustable stats: health, mana, armor, and damage.
+#
+#        AutoBalance.StatModifier*.<Stat> -- only affects non-boss creatures
+#        AutoBalance.StatModifier*.Boss.<Stat> -- only affects bosses
 #
 #        To see this in action, change the `StatModifier` value on the spreadsheet:
 #        https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy
@@ -214,12 +230,14 @@ AutoBalance.InflectionPoint.Boss.PerInstance=""
 #
 #           Default: 1.0
 #
-#        Boss.Global
-#           Further adjusts the multiplier of bosses for all stats. Only applies to creatures considered instance bosses (from dungeons or raids).
+#        Boss.Global | Boss.Health | Boss.Mana | Boss.Armor | Boss.Damage
+#           Sets a SEPARATE stat multiplier for bosses. Is NOT affected by the non-boss modifiers. Only applies to creatures 
+#           considered instance bosses (from dungeons or raids).
+#
+#           Default: If not set for a given instance size/type, defaults to the dungeon/raid default values.
 #
 #           To better understand this effect, see the interactive spreadsheet.
 #
-#           Default: 1.0
 
 ### 5-player dungeons
 AutoBalance.StatModifier.Global=1.0
@@ -227,7 +245,12 @@ AutoBalance.StatModifier.Health=1.0
 AutoBalance.StatModifier.Mana=1.0
 AutoBalance.StatModifier.Armor=1.0
 AutoBalance.StatModifier.Damage=1.0
+
 AutoBalance.StatModifier.Boss.Global=1.0
+AutoBalance.StatModifier.Boss.Health=1.0
+AutoBalance.StatModifier.Boss.Mana=1.0
+AutoBalance.StatModifier.Boss.Armor=1.0
+AutoBalance.StatModifier.Boss.Damage=1.0
 
 ### 5-player heroic dungeons
 AutoBalance.StatModifierHeroic.Global=1.0
@@ -235,7 +258,12 @@ AutoBalance.StatModifierHeroic.Health=1.0
 AutoBalance.StatModifierHeroic.Mana=1.0
 AutoBalance.StatModifierHeroic.Armor=1.0
 AutoBalance.StatModifierHeroic.Damage=1.0
+
 AutoBalance.StatModifierHeroic.Boss.Global=1.0
+AutoBalance.StatModifierHeroic.Boss.Health=1.0
+AutoBalance.StatModifierHeroic.Boss.Mana=1.0
+AutoBalance.StatModifierHeroic.Boss.Armor=1.0
+AutoBalance.StatModifierHeroic.Boss.Damage=1.0
 
 ### Default for all raids
 AutoBalance.StatModifierRaid.Global=1.0
@@ -243,7 +271,12 @@ AutoBalance.StatModifierRaid.Health=1.0
 AutoBalance.StatModifierRaid.Mana=1.0
 AutoBalance.StatModifierRaid.Armor=1.0
 AutoBalance.StatModifierRaid.Damage=1.0
+
 AutoBalance.StatModifierRaid.Boss.Global=1.0
+AutoBalance.StatModifierRaid.Boss.Health=1.0
+AutoBalance.StatModifierRaid.Boss.Mana=1.0
+AutoBalance.StatModifierRaid.Boss.Armor=1.0
+AutoBalance.StatModifierRaid.Boss.Damage=1.0
 
 ### Default for all heroic raids
 AutoBalance.StatModifierRaidHeroic.Global=1.0
@@ -251,7 +284,12 @@ AutoBalance.StatModifierRaidHeroic.Health=1.0
 AutoBalance.StatModifierRaidHeroic.Mana=1.0
 AutoBalance.StatModifierRaidHeroic.Armor=1.0
 AutoBalance.StatModifierRaidHeroic.Damage=1.0
+
 AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Health=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Mana=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Armor=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Damage=1.0
 
 ###
 ### By default, all instances use the settings configured above. To customize settings for a particular instance size,
@@ -264,7 +302,12 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 #AutoBalance.StatModifierRaid10M.Mana=1.0
 #AutoBalance.StatModifierRaid10M.Armor=1.0
 #AutoBalance.StatModifierRaid10M.Damage=1.0
+
 #AutoBalance.StatModifierRaid10M.Boss.Global=1.0
+#AutoBalance.StatModifierRaid10M.Boss.Health=1.0
+#AutoBalance.StatModifierRaid10M.Boss.Mana=1.0
+#AutoBalance.StatModifierRaid10M.Boss.Armor=1.0
+#AutoBalance.StatModifierRaid10M.Boss.Damage=1.0
 
 ### 10-player heroic raids
 #AutoBalance.StatModifierRaid10MHeroic.Global=1.0
@@ -272,7 +315,12 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 #AutoBalance.StatModifierRaid10MHeroic.Mana=1.0
 #AutoBalance.StatModifierRaid10MHeroic.Armor=1.0
 #AutoBalance.StatModifierRaid10MHeroic.Damage=1.0
+
 #AutoBalance.StatModifierRaid10MHeroic.Boss.Global=1.0
+#AutoBalance.StatModifierRaid10MHeroic.Boss.Health=1.0
+#AutoBalance.StatModifierRaid10MHeroic.Boss.Mana=1.0
+#AutoBalance.StatModifierRaid10MHeroic.Boss.Armor=1.0
+#AutoBalance.StatModifierRaid10MHeroic.Boss.Damage=1.0
 
 ### 15-player raids
 #AutoBalance.StatModifierRaid15M.Global=1.0
@@ -280,7 +328,12 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 #AutoBalance.StatModifierRaid15M.Mana=1.0
 #AutoBalance.StatModifierRaid15M.Armor=1.0
 #AutoBalance.StatModifierRaid15M.Damage=1.0
+
 #AutoBalance.StatModifierRaid15M.Boss.Global=1.0
+#AutoBalance.StatModifierRaid15M.Boss.Health=1.0
+#AutoBalance.StatModifierRaid15M.Boss.Mana=1.0
+#AutoBalance.StatModifierRaid15M.Boss.Armor=1.0
+#AutoBalance.StatModifierRaid15M.Boss.Damage=1.0
 
 ### 20-player raids
 #AutoBalance.StatModifierRaid20M.Global=1.0
@@ -288,7 +341,12 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 #AutoBalance.StatModifierRaid20M.Mana=1.0
 #AutoBalance.StatModifierRaid20M.Armor=1.0
 #AutoBalance.StatModifierRaid20M.Damage=1.0
+
 #AutoBalance.StatModifierRaid20M.Boss.Global=1.0
+#AutoBalance.StatModifierRaid20M.Boss.Health=1.0
+#AutoBalance.StatModifierRaid20M.Boss.Mana=1.0
+#AutoBalance.StatModifierRaid20M.Boss.Armor=1.0
+#AutoBalance.StatModifierRaid20M.Boss.Damage=1.0
 
 ### 25-player raids
 #AutoBalance.StatModifierRaid25M.Global=1.0
@@ -296,7 +354,12 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 #AutoBalance.StatModifierRaid25M.Mana=1.0
 #AutoBalance.StatModifierRaid25M.Armor=1.0
 #AutoBalance.StatModifierRaid25M.Damage=1.0
+
 #AutoBalance.StatModifierRaid25M.Boss.Global=1.0
+#AutoBalance.StatModifierRaid25M.Boss.Health=1.0
+#AutoBalance.StatModifierRaid25M.Boss.Mana=1.0
+#AutoBalance.StatModifierRaid25M.Boss.Armor=1.0
+#AutoBalance.StatModifierRaid25M.Boss.Damage=1.0
 
 ### 25-player heroic raids
 #AutoBalance.StatModifierRaid25MHeroic.Global=1.0
@@ -304,7 +367,12 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 #AutoBalance.StatModifierRaid25MHeroic.Mana=1.0
 #AutoBalance.StatModifierRaid25MHeroic.Armor=1.0
 #AutoBalance.StatModifierRaid25MHeroic.Damage=1.0
+
 #AutoBalance.StatModifierRaid25MHeroic.Boss.Global=1.0
+#AutoBalance.StatModifierRaid25MHeroic.Boss.Health=1.0
+#AutoBalance.StatModifierRaid25MHeroic.Boss.Mana=1.0
+#AutoBalance.StatModifierRaid25MHeroic.Boss.Armor=1.0
+#AutoBalance.StatModifierRaid25MHeroic.Boss.Damage=1.0
 
 ### 40-player raids
 #AutoBalance.StatModifierRaid40M.Global=1.0
@@ -312,19 +380,90 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 #AutoBalance.StatModifierRaid40M.Mana=1.0
 #AutoBalance.StatModifierRaid40M.Armor=1.0
 #AutoBalance.StatModifierRaid40M.Damage=1.0
+
 #AutoBalance.StatModifierRaid40M.Boss.Global=1.0
+#AutoBalance.StatModifierRaid40M.Boss.Health=1.0
+#AutoBalance.StatModifierRaid40M.Boss.Mana=1.0
+#AutoBalance.StatModifierRaid40M.Boss.Armor=1.0
+#AutoBalance.StatModifierRaid40M.Boss.Damage=1.0
+
+##########################
+#
+# Stat Scaling - Stat Modifier Overrides
+#
+##########################
+# A note on how the stat modifier settings are prioritized. More specific values REPLACE less-specific values.
+# Bosses and non-boss creatures pull from different settings but work in a similar way.
+#
+# Boss example: High Priest Venoxis (boss, CreatureID 14507) in the Zul'Gurub 20-player raid (InstanceID 309):
+#
+#     StatModifierRaid.Boss.Global=     0.7
+#     StatModifierRaid20M.Boss.Global=  0.8
+#     StatModifier.Boss.PerInstance=    "309 0.9"
+#     StatModifier.PerCreature=         "14507 1.0"
+#
+# Settings are applied from top the bottom, with the bottom setting (1.0) being applied to all stats for the boss.
+# Omitting the "PerCreature" setting would cause the per-instance setting for Zul'Gurub bosses (0.9) to be applied instead, and so on.
+#
+# Non-boss example: Molten Giant (non-boss, CreatureID 11658) in the Molten Core 40-player raid (InstanceID 409):
+#
+#     StatModifierRaid.Damage =     2.1
+#     StatModifierRaid40M.Damage =  2.2
+#     StatModifier.PerInstance =    "409 -1 -1 -1 -1 2.3"
+#     StatModifier.PerCreature=     "11658 -1 -1 -1 -1 2.4"
+#
+# Settings are applied from top the bottom, with the bottom setting (2.4) being applied to the creature's damage multiplier.
+# Omitting the "PerCreature" setting would cause the per-instance setting for Molten Core non-boss damage (2.3) to be applied instead, and so on.
+#
+# Keep in mind that you may use "-1" for any specific override stat to allow less-specific settings to come through.
+#
+# In this way you can make your configs as simple or complicated as you like - if you only want to set some generic dungeon and raid modifiers, everything will
+# work as expected. If you want to tune specific creatures to your liking, you can do that too.
+#
 
 #
 #     AutoBalance.StatModifier.PerInstance
-#        Allows setting a per-instance stat modifier value. Specifying a value of `-1` will skip overriding of that value.
+#        Allows setting per-instance stat modifier values. Specifying a value of `-1` will skip overriding of that value.
 #        You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
 #
-#        Format: "[InstanceID] [Global] [Health] [Mana] [Armor] [Damage] [Boss.Global], [InstanceID] [Global] [Health] [Mana] [Armor] [Damage] [Boss.Global], ..."
+#        ONLY AFFECTS NON-BOSS CREATURES.
 #
-#        Example: AutoBalance.StatModifier.PerInstance="409 1.0 0.8 0.8 1.0 1.2 1.1, 568 -1 -1 -1 -1 -1 1.5, 43 -1 1.2 1.2"
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [Global] [Health] [Mana] [Armor] [Damage], [InstanceID] [Global] [Health] [Mana] [Armor] [Damage], ..."
+#
+#        Example: AutoBalance.StatModifier.PerInstance="409 1.0 0.8 0.8 1.0 1.2, 568 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
 #
 #        Default: Empty string, which disables the feature.
 AutoBalance.StatModifier.PerInstance=""
+
+#
+#     AutoBalance.StatModifier.Boss.PerInstance
+#        Allows setting per-instance stat modifier values for bosses only. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
+#
+#        ONLY AFFECTS BOSSES.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [Boss.Global] [Boss.Health] [Boss.Mana] [Boss.Armor] [Boss.Damage], [InstanceID] [Boss.Global] [Boss.Health] [Boss.Mana] [Boss.Armor] [Boss.Damage], ..."
+#
+#        Example: AutoBalance.StatModifier.Boss.PerInstance="409 1.0 0.8 0.8 1.0 1.2, 568 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#
+#        Default: Empty string, which disables the feature.
+AutoBalance.StatModifier.Boss.PerInstance=""
+
+#
+#     AutoBalance.StatModifier.Boss.PerCreature
+#        Allows setting per-creature stat modifier values. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per CreatureID.
+#
+#        Format: "[CreatureID] [Global] [Health] [Mana] [Armor] [Damage], [CreatureID] [Global] [Health] [Mana] [Armor] [Damage], ..."
+#
+#        Example: AutoBalance.StatModifier.Boss.PerInstance="14507 1.0 0.8 0.8 1.0 1.2, 11372 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#
+#        Default: Empty string, which disables the feature.
+AutoBalance.StatModifier.PerCreature=""
 
 #
 #     AutoBalance.MinHPModifier
@@ -344,12 +483,11 @@ AutoBalance.MinManaModifier=0.01
 #        Default:     0.01
 AutoBalance.MinDamageModifier=0.01
 
+##########################
 #
-#     AutoBalance.playerCountDifficultyOffset
-#        Offset of players inside an instance. Affects all instance types.
-#        Default:     0
-AutoBalance.playerCountDifficultyOffset=0
-
+# Misc Settings
+#
+##########################
 #
 #     AutoBalance.PerDungeonPlayerCounts
 #        Allows setting a per-instance setting for minimum number of players to scale. For example, dungeons could remain at 5 players, but raids could be chosen to scale down to 5 players as well.
@@ -514,7 +652,7 @@ AutoBalance.reward.dungeonToken = 47241
 AutoBalance.reward.MinPlayerReward = 1
 
 # The following variables are deprecated and should not be used in new deployments.
-# They are still applied to support backwards compatability, but will be removed entirely in a future release.
+# They will still be applied to support backwards compatability, but will be removed entirely in a future release.
 # Their entire functionality (and more) has been moved to new settings referenced in this config file.
 #
 #   AutoBalance.PerDungeonScaling

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -168,23 +168,131 @@ AutoBalance.PerDungeonScaling=""
 #        To disable, leave empty. This is the default setting.
 AutoBalance.PerDungeonBossScaling=""
 
-#     AutoBalance.rate.*
-#        Rate that is applied just before the multiplier is used on enemies. Allows you to linearly shift the curve up or
-#        down to increase or decrease a particualar stat.
+#     AutoBalance.StatModifier* series
+#        The difficulty curve (as defined by the InflectionPoint settings) determines the base multiplier. The base
+#        multiplier is then adjusted (multiplied) by the appropriate StatModifier setting. This allows you to control
+#        the balance of how scaling affects the four adjustable stats: health, mana, armor, and damage.
 #
-#        Note that global rate will increase all other rates. If global=2.0 and damage=1.5, damage will be multiplied by 3.0.
+#        To see this in action, change the `StatModifier` value on the spreadsheet:
+#        https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy
 #
-#        Example: With AutoBalance.rate.health=1.0, an enemy has 1000 health after scaling.
-#                 With AutoBalance.rate.health=1.5, an enemy has 1500 health after scaling and rate adjustment.
+#        To use it, copy the sheet to your own Google Drive and edit the values on the left with the yellow background.
+#        The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given dungeon.
 #
-#        Consult the interactive spreadsheet for more examples.
+#        Global
+#           Multiply the other four settings by this value. Allows you to increase all the stats (health, mana, armor, 
+#           damage) with a single adjustment. Both the global value and the stat-specific value are used at the same time.
 #
-#        Default:     1.0
-AutoBalance.rate.global = 1.0
-AutoBalance.rate.health = 1.0
-AutoBalance.rate.mana   = 1.0
-AutoBalance.rate.armor  = 1.0
-AutoBalance.rate.damage = 1.0
+#           Example: If "Global" is 0.5, and "Health" is 1.5, the health of the creature will be multiplied by 0.75 of 
+#                    its value (after adjusting for the number of players).
+#
+#           Default: 1.0
+#
+#        Health | Mana | Armor | Damage
+#           Adjusts the StatModifier for the appropriate stat. Affected by the Global StatModifier above.
+#
+#           Default: 1.0
+#
+#        Boss.Global
+#           Further adjusts the multiplier of bosses for all stats. Only applies to creatures considered dungeon bosses (from dungeons or raids).
+#
+#           To better understand this effect, see the interactive spreadsheet.
+#
+#           Default: 1.0
+
+
+### 5-player dungeons
+AutoBalance.StatModifier.Global=0.5
+AutoBalance.StatModifier.Health=1.0
+AutoBalance.StatModifier.Mana=1.0
+AutoBalance.StatModifier.Armor=1.0
+AutoBalance.StatModifier.Damage=1.0
+AutoBalance.StatModifier.Boss.Global=1.5
+
+### 5-player heroic dungeons
+AutoBalance.StatModifierHeroic.Global=1.0
+AutoBalance.StatModifierHeroic.Health=1.0
+AutoBalance.StatModifierHeroic.Mana=1.0
+AutoBalance.StatModifierHeroic.Armor=1.0
+AutoBalance.StatModifierHeroic.Damage=1.0
+AutoBalance.StatModifierHeroic.Boss.Global=1.0
+
+### Default for all raids
+AutoBalance.StatModifierRaid.Global=1.0
+AutoBalance.StatModifierRaid.Health=1.0
+AutoBalance.StatModifierRaid.Mana=1.0
+AutoBalance.StatModifierRaid.Armor=1.0
+AutoBalance.StatModifierRaid.Damage=1.0
+AutoBalance.StatModifierRaid.Boss.Global=1.0
+
+### Default for all heroic raids
+AutoBalance.StatModifierRaidHeroic.Global=1.0
+AutoBalance.StatModifierRaidHeroic.Health=1.0
+AutoBalance.StatModifierRaidHeroic.Mana=1.0
+AutoBalance.StatModifierRaidHeroic.Armor=1.0
+AutoBalance.StatModifierRaidHeroic.Damage=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
+
+###
+### By default, all instances use the settings configured above. To customize settings for a particular instance size,
+### uncomment the appropriate configuration lines below and adjust values to your liking.
+###
+
+### 10-player raids
+AutoBalance.StatModifierRaid10M.Global=1.0
+AutoBalance.StatModifierRaid10M.Health=1.0
+AutoBalance.StatModifierRaid10M.Mana=1.0
+AutoBalance.StatModifierRaid10M.Armor=1.0
+AutoBalance.StatModifierRaid10M.Damage=1.0
+AutoBalance.StatModifierRaid10M.Boss.Global=1.0
+
+### 10-player heroic raids
+AutoBalance.StatModifierRaid10MHeroic.Global=1.0
+AutoBalance.StatModifierRaid10MHeroic.Health=1.0
+AutoBalance.StatModifierRaid10MHeroic.Mana=1.0
+AutoBalance.StatModifierRaid10MHeroic.Armor=1.0
+AutoBalance.StatModifierRaid10MHeroic.Damage=1.0
+AutoBalance.StatModifierRaid10MHeroic.Boss.Global=1.0
+
+### 15-player raids
+AutoBalance.StatModifierRaid15M.Global=1.0
+AutoBalance.StatModifierRaid15M.Health=1.0
+AutoBalance.StatModifierRaid15M.Mana=1.0
+AutoBalance.StatModifierRaid15M.Armor=1.0
+AutoBalance.StatModifierRaid15M.Damage=1.0
+AutoBalance.StatModifierRaid15M.Boss.Global=1.0
+
+### 20-player raids
+AutoBalance.StatModifierRaid20M.Global=1.0
+AutoBalance.StatModifierRaid20M.Health=1.0
+AutoBalance.StatModifierRaid20M.Mana=1.0
+AutoBalance.StatModifierRaid20M.Armor=1.0
+AutoBalance.StatModifierRaid20M.Damage=1.0
+AutoBalance.StatModifierRaid20M.Boss.Global=1.0
+
+### 25-player raids
+AutoBalance.StatModifierRaid25M.Global=1.0
+AutoBalance.StatModifierRaid25M.Health=1.0
+AutoBalance.StatModifierRaid25M.Mana=1.0
+AutoBalance.StatModifierRaid25M.Armor=1.0
+AutoBalance.StatModifierRaid25M.Damage=1.0
+AutoBalance.StatModifierRaid25M.Boss.Global=1.0
+
+### 25-player heroic raids
+AutoBalance.StatModifierRaid25MHeroic.Global=1.0
+AutoBalance.StatModifierRaid25MHeroic.Health=1.0
+AutoBalance.StatModifierRaid25MHeroic.Mana=1.0
+AutoBalance.StatModifierRaid25MHeroic.Armor=1.0
+AutoBalance.StatModifierRaid25MHeroic.Damage=1.0
+AutoBalance.StatModifierRaid25MHeroic.Boss.Global=1.0
+
+### 40-player raids
+AutoBalance.StatModifierRaid40M.Global=1.0
+AutoBalance.StatModifierRaid40M.Health=1.0
+AutoBalance.StatModifierRaid40M.Mana=1.0
+AutoBalance.StatModifierRaid40M.Armor=1.0
+AutoBalance.StatModifierRaid40M.Damage=1.0
+AutoBalance.StatModifierRaid40M.Boss.Global=1.0
 
 #
 #     AutoBalance.MinHPModifier
@@ -373,3 +481,13 @@ AutoBalance.reward.dungeonToken = 47241
 #       Default:     1
 AutoBalance.reward.MinPlayerReward = 1
 
+# The following variables are deprecated and should not be used in new deployments.
+# They will still be applied to support backwards compatability, but will be removed entirely in a future release.
+# Their entire functionality (and more) has been moved to new settings referenced in this config file.
+#
+#   AutoBalance.BossInflectionMult
+#   AutoBalance.rate.global
+#   AutoBalance.rate.health
+#   AutoBalance.rate.mana
+#   AutoBalance.rate.armor
+#   AutoBalance.rate.damage

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -65,7 +65,9 @@ AutoBalance.enable=1
 #           Default: 1.0
 #
 #       BossModifier
-#           Further adjusts the inflection point of bosses. Only applies to creatures considered dungeon bosses (from dungeons or raids).
+#           InflectionPoint is multiplied by this value for creatures considered dungeon bosses (from dungeons or raids). 
+#           It is a multiplier, not a new Inflection Point. Values higher than 1.0 will make enemies easier at lower player
+#           counts while lower than 1.0 will make enemies easier at lower player counts.
 #
 #           To better understand this effect, see the interactive spreadsheet explained below.
 #
@@ -151,22 +153,41 @@ AutoBalance.InflectionPointRaidHeroic.BossModifier=1.0
 #AutoBalance.InflectionPointRaid40M.BossModifier=1.0
 
 #
-#     AutoBalance.PerDungeonScaling
-#        Allows setting a per-dungeon or per-raid scaling inflection value
-#        Formatted as "[dungeonId] [inflectionValue], [dungeonId] [inflectionValue], [dungeonId] [inflectionValue], ..."
-#        Example: AutoBalance.PerDungeonScaling="229 0.15, 309 0.3"
-#        For dungeons not listed, the default inflection value provided above for the dungeon's difficulty will be used.
-#        To disable, leave empty. This is the default setting.
-AutoBalance.PerDungeonScaling=""
+#     AutoBalance.InflectionPoint.PerInstance
+#        Sets Inflection Point settings for specific `InstanceID`s.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Specifying a value of `-1` will skip overriding of that value. For instances not listed, the default inflection value for the instance's 
+#        difficulty and size will be used. You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
+#
+#        Format: "[InstanceID] [InflectionPoint] [CurveFloor] [CurveCeiling], [InstanceID] [InflectionPoint] [CurveFloor] [CurveCeiling], ..."
+#
+#        Example: AutoBalance.InflectionPoint.PerInstance="229 0.4 0.0 1.5, 309 -1 0.0 1.1, 48 0.3"
+#
+#        Default: ""
+#
+AutoBalance.InflectionPoint.PerInstance=""
 
 #
-#     AutoBalance.PerDungeonBossScaling
-#        Allows setting a per-dungeon scaling inflection value for bosses
-#        Formatted as "[dungeonId] [inflectionValue], [dungeonId] [inflectionValue], [dungeonId] [inflectionValue], ..."
-#        Example: AutoBalance.PerDungeonBossScaling="229 0.5, 309 1.2, 409 1, 249 1.5"
-#        For dungeons not listed, the default inflection value provided above for the dungeon's difficulty will be used.
-#        To disable, leave empty. This is the default setting.
-AutoBalance.PerDungeonBossScaling=""
+#     AutoBalance.InflectionPoint.Boss.PerInstance
+#        Sets Inflection Point settings for all bosses in specific `InstanceID`s. Note that the first value is "InflectionPointMultiplier", which behaves
+#        identically to the BossModifier setting. The "normal" inflection point is multiplied by this value for bosses. To better understand this effect, 
+#        see the interactive spreadsheet.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        For instances not listed, the default inflection value for the instance's difficulty and size will be used. Only one set of values should be specified
+#        per InstanceID.
+#
+#        Format: "[InstanceID] [InflectionPointMultiplier], [InstanceID] [InflectionPointMultiplier], ..."
+#
+#        Example: AutoBalance.InflectionPoint.Boss.PerInstance="229 1.2, 309 1.5, 48 1.25"
+#
+#        Default: ""
+#
+AutoBalance.InflectionPoint.Boss.PerInstance=""
+
 
 #     AutoBalance.StatModifier* series
 #        The difficulty curve (as defined by the InflectionPoint settings) determines the base multiplier. The base
@@ -177,7 +198,7 @@ AutoBalance.PerDungeonBossScaling=""
 #        https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy
 #
 #        To use it, copy the sheet to your own Google Drive and edit the values on the left with the yellow background.
-#        The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given dungeon.
+#        The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given instance.
 #
 #        Global
 #           Multiply the other four settings by this value. Allows you to increase all the stats (health, mana, armor, 
@@ -194,12 +215,11 @@ AutoBalance.PerDungeonBossScaling=""
 #           Default: 1.0
 #
 #        Boss.Global
-#           Further adjusts the multiplier of bosses for all stats. Only applies to creatures considered dungeon bosses (from dungeons or raids).
+#           Further adjusts the multiplier of bosses for all stats. Only applies to creatures considered instance bosses (from dungeons or raids).
 #
 #           To better understand this effect, see the interactive spreadsheet.
 #
 #           Default: 1.0
-
 
 ### 5-player dungeons
 AutoBalance.StatModifier.Global=1.0
@@ -295,16 +315,16 @@ AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
 #AutoBalance.StatModifierRaid40M.Boss.Global=1.0
 
 #
-#     AutoBalance.StatModifierPerDungeon
-#        Allows setting a per-dungeon stat modifier value. Specifying a value of `-1` will use the instance-level settings for that value.
-#        You may omit entries from the end of the string if desired. Only one set of values should be specified per dungeonId.
+#     AutoBalance.StatModifier.PerInstance
+#        Allows setting a per-instance stat modifier value. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
 #
-#        Format: "[dungeonId] [global] [health] [mana] [armor] [damage] [boss.global], [dungeonId] [global] [health] [mana] [armor] [damage] [boss.global], ..."
+#        Format: "[InstanceID] [Global] [Health] [Mana] [Armor] [Damage] [Boss.Global], [InstanceID] [Global] [Health] [Mana] [Armor] [Damage] [Boss.Global], ..."
 #
-#        Example: AutoBalance.ModifierPerDungeon="409 1.0 0.8 0.8 1.0 1.2 1.1, 568 -1 -1 -1 -1 -1 1.5, 43 -1 1.2 1.2"
+#        Example: AutoBalance.StatModifier.PerInstance="409 1.0 0.8 0.8 1.0 1.2 1.1, 568 -1 -1 -1 -1 -1 1.5, 43 -1 1.2 1.2"
 #
 #        Default: Empty string, which disables the feature.
-AutoBalance.StatModifierPerDungeon=""
+AutoBalance.StatModifier.PerInstance=""
 
 #
 #     AutoBalance.MinHPModifier
@@ -332,11 +352,11 @@ AutoBalance.playerCountDifficultyOffset=0
 
 #
 #     AutoBalance.PerDungeonPlayerCounts
-#        Allows setting a per-dungeon setting for minimum number of players to scale. For example, dungeons could remain at 5 players, but raids could be chosen to scale down to 5 players as well.
-#        Formatted as "[dungeonId] [playerCount], [dungeonId] [playerCount], [dungeonId] [playerCount], ..."
+#        Allows setting a per-instance setting for minimum number of players to scale. For example, dungeons could remain at 5 players, but raids could be chosen to scale down to 5 players as well.
+#        Formatted as "[InstanceID] [playerCount], [InstanceID] [playerCount], [InstanceID] [playerCount], ..."
 #        Example: AutoBalance.PerDungeonPlayerCounts="33 1,34 1,36 1,43 1,47 1,48 1,70 1,90 1,109 1,129 1,189 1,209 1,349 1,389 1, 289 2, 329 2, 230 2, 429 2, 309 5, 409 5"
-#        For dungeons not listed, the dungeon's original player count (5, 10, 20, 25, or 40) is used as the minimum, meaning no scaling will take place.
-#        To disable, leave empty; all dungeons will then scale down to 1 player minimum. This is the default setting.
+#        For instances not listed, the instance's original player count (5, 10, 20, 25, or 40) is used as the minimum, meaning no scaling will take place.
+#        To disable, leave empty; all instances will then scale down to 1 player minimum. This is the default setting.
 #        Default: ""
 #
 AutoBalance.PerDungeonPlayerCounts=""
@@ -450,7 +470,7 @@ AutoBalance.DungeonsOnly=1
 AutoBalance.DebugLevel=2
 
 #
-#     .AutoBalance.PlayerChangeNotify
+#     AutoBalance.PlayerChangeNotify
 #        Set Auto Notifications to all players in Instance that player count has changed.
 #        Default:     1 (1 = ON, 0 = OFF)
 AutoBalance.PlayerChangeNotify=1
@@ -494,9 +514,11 @@ AutoBalance.reward.dungeonToken = 47241
 AutoBalance.reward.MinPlayerReward = 1
 
 # The following variables are deprecated and should not be used in new deployments.
-# They will still be applied to support backwards compatability, but will be removed entirely in a future release.
+# They are still applied to support backwards compatability, but will be removed entirely in a future release.
 # Their entire functionality (and more) has been moved to new settings referenced in this config file.
 #
+#   AutoBalance.PerDungeonScaling
+#   AutoBalance.PerDungeonBossScaling
 #   AutoBalance.BossInflectionMult
 #   AutoBalance.rate.global
 #   AutoBalance.rate.health

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -74,7 +74,7 @@ AutoBalance.enable=1
 #
 #     An interactive spreadsheet is available for you to visually see what effect your settings have on the difficulty curve.
 #
-#     https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/edit?usp=sharing
+#     https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy
 #
 #     To use it, copy the sheet to your own Google Drive and edit the values on the left with the yellow background.
 #     The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given dungeon.

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -119,10 +119,11 @@ public:
     uint8 selectedLevel = 0;
     // this is used to detect creatures that update their entry
     uint32 entry = 0;
-    float DamageMultiplier = 1;
-    float HealthMultiplier = 1;
-    float ManaMultiplier = 1;
-    float ArmorMultiplier = 1;
+    float DamageMultiplier;
+    float HealthMultiplier;
+    float ManaMultiplier;
+    float ArmorMultiplier;
+    float CCDurationMultiplier;
 };
 
 class AutoBalanceMapInfo : public DataMap::Base
@@ -138,13 +139,14 @@ class AutoBalanceStatModifiers : public DataMap::Base
 {
 public:
     AutoBalanceStatModifiers() {}
-    AutoBalanceStatModifiers(float global, float health, float mana, float armor, float damage) :
-        global(global), health(health), mana(mana), armor(armor), damage(damage) {}
+    AutoBalanceStatModifiers(float global, float health, float mana, float armor, float damage, float ccduration) :
+        global(global), health(health), mana(mana), armor(armor), damage(damage), ccduration(ccduration) {}
     float global;
     float health;
     float mana;
     float armor;
     float damage;
+    float ccduration;
 };
 
 class AutoBalanceInflectionPointSettings : public DataMap::Base
@@ -171,7 +173,7 @@ static std::map<uint32, AutoBalanceStatModifiers> statModifierCreatureOverrides;
 static int8 PlayerCountDifficultyOffset, LevelScaling, higherOffset, lowerOffset;
 static uint32 rewardRaid, rewardDungeon, MinPlayerReward;
 static bool enabled, LevelEndGameBoost, DungeonsOnly, PlayerChangeNotify, LevelUseDb, rewardEnabled, DungeonScaleDownXP, DungeonScaleDownMoney;
-static float MinHPModifier, MinManaModifier, MinDamageModifier;
+static float MinHPModifier, MinManaModifier, MinDamageModifier, MinCCDurationModifier, MaxCCDurationModifier;
 
 // InflectionPoint*
 static float InflectionPoint, InflectionPointCurveFloor, InflectionPointCurveCeiling, InflectionPointBoss;
@@ -188,32 +190,32 @@ static float InflectionPointRaid25MHeroic, InflectionPointRaid25MHeroicCurveFloo
 static float InflectionPointRaid40M, InflectionPointRaid40MCurveFloor, InflectionPointRaid40MCurveCeiling, InflectionPointRaid40MBoss;
 
 // StatModifier*
-static float StatModifier_Global, StatModifier_Health, StatModifier_Mana, StatModifier_Armor, StatModifier_Damage;
-static float StatModifierHeroic_Global, StatModifierHeroic_Health, StatModifierHeroic_Mana, StatModifierHeroic_Armor, StatModifierHeroic_Damage;
-static float StatModifierRaid_Global, StatModifierRaid_Health, StatModifierRaid_Mana, StatModifierRaid_Armor, StatModifierRaid_Damage;
-static float StatModifierRaidHeroic_Global, StatModifierRaidHeroic_Health, StatModifierRaidHeroic_Mana, StatModifierRaidHeroic_Armor, StatModifierRaidHeroic_Damage;
+static float StatModifier_Global, StatModifier_Health, StatModifier_Mana, StatModifier_Armor, StatModifier_Damage, StatModifier_CCDuration;
+static float StatModifierHeroic_Global, StatModifierHeroic_Health, StatModifierHeroic_Mana, StatModifierHeroic_Armor, StatModifierHeroic_Damage, StatModifierHeroic_CCDuration;
+static float StatModifierRaid_Global, StatModifierRaid_Health, StatModifierRaid_Mana, StatModifierRaid_Armor, StatModifierRaid_Damage, StatModifierRaid_CCDuration;
+static float StatModifierRaidHeroic_Global, StatModifierRaidHeroic_Health, StatModifierRaidHeroic_Mana, StatModifierRaidHeroic_Armor, StatModifierRaidHeroic_Damage, StatModifierRaidHeroic_CCDuration;
 
-static float StatModifierRaid10M_Global, StatModifierRaid10M_Health, StatModifierRaid10M_Mana, StatModifierRaid10M_Armor, StatModifierRaid10M_Damage;
-static float StatModifierRaid10MHeroic_Global, StatModifierRaid10MHeroic_Health, StatModifierRaid10MHeroic_Mana, StatModifierRaid10MHeroic_Armor, StatModifierRaid10MHeroic_Damage;
-static float StatModifierRaid15M_Global, StatModifierRaid15M_Health, StatModifierRaid15M_Mana, StatModifierRaid15M_Armor, StatModifierRaid15M_Damage;
-static float StatModifierRaid20M_Global, StatModifierRaid20M_Health, StatModifierRaid20M_Mana, StatModifierRaid20M_Armor, StatModifierRaid20M_Damage;
-static float StatModifierRaid25M_Global, StatModifierRaid25M_Health, StatModifierRaid25M_Mana, StatModifierRaid25M_Armor, StatModifierRaid25M_Damage;
-static float StatModifierRaid25MHeroic_Global, StatModifierRaid25MHeroic_Health, StatModifierRaid25MHeroic_Mana, StatModifierRaid25MHeroic_Armor, StatModifierRaid25MHeroic_Damage;
-static float StatModifierRaid40M_Global, StatModifierRaid40M_Health, StatModifierRaid40M_Mana, StatModifierRaid40M_Armor, StatModifierRaid40M_Damage;
+static float StatModifierRaid10M_Global, StatModifierRaid10M_Health, StatModifierRaid10M_Mana, StatModifierRaid10M_Armor, StatModifierRaid10M_Damage, StatModifierRaid10M_CCDuration;
+static float StatModifierRaid10MHeroic_Global, StatModifierRaid10MHeroic_Health, StatModifierRaid10MHeroic_Mana, StatModifierRaid10MHeroic_Armor, StatModifierRaid10MHeroic_Damage, StatModifierRaid10MHeroic_CCDuration;
+static float StatModifierRaid15M_Global, StatModifierRaid15M_Health, StatModifierRaid15M_Mana, StatModifierRaid15M_Armor, StatModifierRaid15M_Damage, StatModifierRaid15M_CCDuration;
+static float StatModifierRaid20M_Global, StatModifierRaid20M_Health, StatModifierRaid20M_Mana, StatModifierRaid20M_Armor, StatModifierRaid20M_Damage, StatModifierRaid20M_CCDuration;
+static float StatModifierRaid25M_Global, StatModifierRaid25M_Health, StatModifierRaid25M_Mana, StatModifierRaid25M_Armor, StatModifierRaid25M_Damage, StatModifierRaid25M_CCDuration;
+static float StatModifierRaid25MHeroic_Global, StatModifierRaid25MHeroic_Health, StatModifierRaid25MHeroic_Mana, StatModifierRaid25MHeroic_Armor, StatModifierRaid25MHeroic_Damage, StatModifierRaid25MHeroic_CCDuration;
+static float StatModifierRaid40M_Global, StatModifierRaid40M_Health, StatModifierRaid40M_Mana, StatModifierRaid40M_Armor, StatModifierRaid40M_Damage, StatModifierRaid40M_CCDuration;
 
 // StatModifier* (Boss)
-static float StatModifier_Boss_Global, StatModifier_Boss_Health, StatModifier_Boss_Mana, StatModifier_Boss_Armor, StatModifier_Boss_Damage;
-static float StatModifierHeroic_Boss_Global, StatModifierHeroic_Boss_Health, StatModifierHeroic_Boss_Mana, StatModifierHeroic_Boss_Armor, StatModifierHeroic_Boss_Damage;
-static float StatModifierRaid_Boss_Global, StatModifierRaid_Boss_Health, StatModifierRaid_Boss_Mana, StatModifierRaid_Boss_Armor, StatModifierRaid_Boss_Damage;
-static float StatModifierRaidHeroic_Boss_Global, StatModifierRaidHeroic_Boss_Health, StatModifierRaidHeroic_Boss_Mana, StatModifierRaidHeroic_Boss_Armor, StatModifierRaidHeroic_Boss_Damage;
+static float StatModifier_Boss_Global, StatModifier_Boss_Health, StatModifier_Boss_Mana, StatModifier_Boss_Armor, StatModifier_Boss_Damage, StatModifier_Boss_CCDuration;
+static float StatModifierHeroic_Boss_Global, StatModifierHeroic_Boss_Health, StatModifierHeroic_Boss_Mana, StatModifierHeroic_Boss_Armor, StatModifierHeroic_Boss_Damage, StatModifierHeroic_Boss_CCDuration;
+static float StatModifierRaid_Boss_Global, StatModifierRaid_Boss_Health, StatModifierRaid_Boss_Mana, StatModifierRaid_Boss_Armor, StatModifierRaid_Boss_Damage, StatModifierRaid_Boss_CCDuration;
+static float StatModifierRaidHeroic_Boss_Global, StatModifierRaidHeroic_Boss_Health, StatModifierRaidHeroic_Boss_Mana, StatModifierRaidHeroic_Boss_Armor, StatModifierRaidHeroic_Boss_Damage, StatModifierRaidHeroic_Boss_CCDuration;
 
-static float StatModifierRaid10M_Boss_Global, StatModifierRaid10M_Boss_Health, StatModifierRaid10M_Boss_Mana, StatModifierRaid10M_Boss_Armor, StatModifierRaid10M_Boss_Damage;
-static float StatModifierRaid10MHeroic_Boss_Global, StatModifierRaid10MHeroic_Boss_Health, StatModifierRaid10MHeroic_Boss_Mana, StatModifierRaid10MHeroic_Boss_Armor, StatModifierRaid10MHeroic_Boss_Damage;
-static float StatModifierRaid15M_Boss_Global, StatModifierRaid15M_Boss_Health, StatModifierRaid15M_Boss_Mana, StatModifierRaid15M_Boss_Armor, StatModifierRaid15M_Boss_Damage;
-static float StatModifierRaid20M_Boss_Global, StatModifierRaid20M_Boss_Health, StatModifierRaid20M_Boss_Mana, StatModifierRaid20M_Boss_Armor, StatModifierRaid20M_Boss_Damage;
-static float StatModifierRaid25M_Boss_Global, StatModifierRaid25M_Boss_Health, StatModifierRaid25M_Boss_Mana, StatModifierRaid25M_Boss_Armor, StatModifierRaid25M_Boss_Damage;
-static float StatModifierRaid25MHeroic_Boss_Global, StatModifierRaid25MHeroic_Boss_Health, StatModifierRaid25MHeroic_Boss_Mana, StatModifierRaid25MHeroic_Boss_Armor, StatModifierRaid25MHeroic_Boss_Damage;
-static float StatModifierRaid40M_Boss_Global, StatModifierRaid40M_Boss_Health, StatModifierRaid40M_Boss_Mana, StatModifierRaid40M_Boss_Armor, StatModifierRaid40M_Boss_Damage;
+static float StatModifierRaid10M_Boss_Global, StatModifierRaid10M_Boss_Health, StatModifierRaid10M_Boss_Mana, StatModifierRaid10M_Boss_Armor, StatModifierRaid10M_Boss_Damage, StatModifierRaid10M_Boss_CCDuration;
+static float StatModifierRaid10MHeroic_Boss_Global, StatModifierRaid10MHeroic_Boss_Health, StatModifierRaid10MHeroic_Boss_Mana, StatModifierRaid10MHeroic_Boss_Armor, StatModifierRaid10MHeroic_Boss_Damage, StatModifierRaid10MHeroic_Boss_CCDuration;
+static float StatModifierRaid15M_Boss_Global, StatModifierRaid15M_Boss_Health, StatModifierRaid15M_Boss_Mana, StatModifierRaid15M_Boss_Armor, StatModifierRaid15M_Boss_Damage, StatModifierRaid15M_Boss_CCDuration;
+static float StatModifierRaid20M_Boss_Global, StatModifierRaid20M_Boss_Health, StatModifierRaid20M_Boss_Mana, StatModifierRaid20M_Boss_Armor, StatModifierRaid20M_Boss_Damage, StatModifierRaid20M_Boss_CCDuration;
+static float StatModifierRaid25M_Boss_Global, StatModifierRaid25M_Boss_Health, StatModifierRaid25M_Boss_Mana, StatModifierRaid25M_Boss_Armor, StatModifierRaid25M_Boss_Damage, StatModifierRaid25M_Boss_CCDuration;
+static float StatModifierRaid25MHeroic_Boss_Global, StatModifierRaid25MHeroic_Boss_Health, StatModifierRaid25MHeroic_Boss_Mana, StatModifierRaid25MHeroic_Boss_Armor, StatModifierRaid25MHeroic_Boss_Damage, StatModifierRaid25MHeroic_Boss_CCDuration;
+static float StatModifierRaid40M_Boss_Global, StatModifierRaid40M_Boss_Health, StatModifierRaid40M_Boss_Mana, StatModifierRaid40M_Boss_Armor, StatModifierRaid40M_Boss_Damage, StatModifierRaid40M_Boss_CCDuration;
 
 int GetValidDebugLevel()
 {
@@ -296,13 +298,15 @@ std::map<uint32, AutoBalanceStatModifiers> LoadStatModifierOverrides(std::string
         if (val4.empty()) { val4 = "-1"; }
         if (val5.empty()) { val5 = "-1"; }
         if (val6.empty()) { val6 = "-1"; }
+        if (val7.empty()) { val7 = "-1"; }
 
         AutoBalanceStatModifiers statSettings = AutoBalanceStatModifiers(
             atof(val2.c_str()),
             atof(val3.c_str()),
             atof(val4.c_str()),
             atof(val5.c_str()),
-            atof(val6.c_str())
+            atof(val6.c_str()),
+            atof(val7.c_str())
         );
 
         overrideMap[dungeonMapId] = statSettings;
@@ -470,25 +474,25 @@ class AutoBalance_WorldScript : public WorldScript
         if (sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", false, false))
             LOG_WARN("server.loading", "mod-autobalance: deprecated value `AutoBalance.BossInflectionMult` defined in `AutoBalance.conf`. This variable will be removed in a future release. Please see `AutoBalance.conf.dist` for more details.");
 
-        InflectionPoint =                           sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint", 0.5f);
-        InflectionPointCurveFloor =                 sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint.CurveFloor", 0.0f);
-        InflectionPointCurveCeiling =               sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint.CurveCeiling", 1.0f);
-        InflectionPointBoss =                       sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false)); // `AutoBalance.BossInflectionMult` for backwards compatibility
+        InflectionPoint =                           sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint", 0.5f, false);
+        InflectionPointCurveFloor =                 sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint.CurveFloor", 0.0f, false);
+        InflectionPointCurveCeiling =               sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint.CurveCeiling", 1.0f, false);
+        InflectionPointBoss =                       sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false), false); // `AutoBalance.BossInflectionMult` for backwards compatibility
 
-        InflectionPointHeroic =                     sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic", 0.5f);
-        InflectionPointHeroicCurveFloor =           sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic.CurveFloor", 0.0f);
-        InflectionPointHeroicCurveCeiling =         sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic.CurveCeiling", 1.0f);
-        InflectionPointHeroicBoss =                 sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false)); // `AutoBalance.BossInflectionMult` for backwards compatibility
+        InflectionPointHeroic =                     sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic", 0.5f, false);
+        InflectionPointHeroicCurveFloor =           sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic.CurveFloor", 0.0f, false);
+        InflectionPointHeroicCurveCeiling =         sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic.CurveCeiling", 1.0f, false);
+        InflectionPointHeroicBoss =                 sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false), false); // `AutoBalance.BossInflectionMult` for backwards compatibility
 
-        InflectionPointRaid =                       sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid", 0.5f);
-        InflectionPointRaidCurveFloor =             sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid.CurveFloor", 0.0f);
-        InflectionPointRaidCurveCeiling =           sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid.CurveCeiling", 1.0f);
-        InflectionPointRaidBoss =                   sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false)); // `AutoBalance.BossInflectionMult` for backwards compatibility
+        InflectionPointRaid =                       sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid", 0.5f, false);
+        InflectionPointRaidCurveFloor =             sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid.CurveFloor", 0.0f, false);
+        InflectionPointRaidCurveCeiling =           sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid.CurveCeiling", 1.0f, false);
+        InflectionPointRaidBoss =                   sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false), false); // `AutoBalance.BossInflectionMult` for backwards compatibility
 
-        InflectionPointRaidHeroic =                 sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic", 0.5f);
-        InflectionPointRaidHeroicCurveFloor =       sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic.CurveFloor", 0.0f);
-        InflectionPointRaidHeroicCurveCeiling =     sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic.CurveCeiling", 1.0f);
-        InflectionPointRaidHeroicBoss =             sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false)); // `AutoBalance.BossInflectionMult` for backwards compatibility
+        InflectionPointRaidHeroic =                 sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic", 0.5f, false);
+        InflectionPointRaidHeroicCurveFloor =       sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic.CurveFloor", 0.0f, false);
+        InflectionPointRaidHeroicCurveCeiling =     sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic.CurveCeiling", 1.0f, false);
+        InflectionPointRaidHeroicBoss =             sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false), false); // `AutoBalance.BossInflectionMult` for backwards compatibility
 
         InflectionPointRaid10M =                    sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10M", InflectionPointRaid, false);
         InflectionPointRaid10MCurveFloor =          sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10M.CurveFloor", InflectionPointRaidCurveFloor, false);
@@ -539,56 +543,64 @@ class AutoBalance_WorldScript : public WorldScript
             LOG_WARN("server.loading", "mod-autobalance: deprecated value `AutoBalance.rate.damage` defined in `AutoBalance.conf`. This variable will be removed in a future release. Please see `AutoBalance.conf.dist` for more details.");
 
         // 5-player dungeons
-        StatModifier_Global =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
-        StatModifier_Health =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
-        StatModifier_Mana =                         sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
-        StatModifier_Armor =                        sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
-        StatModifier_Damage =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifier_Global =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false), false); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifier_Health =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false), false); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifier_Mana =                         sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false), false); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifier_Armor =                        sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)), false; // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifier_Damage =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false), false); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifier_CCDuration =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifier.CCDuration", -1.0f, false);
 
-        StatModifier_Boss_Global =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
-        StatModifier_Boss_Health =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
-        StatModifier_Boss_Mana =                    sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
-        StatModifier_Boss_Armor =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
-        StatModifier_Boss_Damage =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifier_Boss_Global =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false), false); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifier_Boss_Health =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false), false); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifier_Boss_Mana =                    sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false), false); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifier_Boss_Armor =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false), false); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifier_Boss_Damage =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false), false); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifier_Boss_CCDuration =              sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.CCDuration", -1.0f, false);
 
         // 5-player heroic dungeons
-        StatModifierHeroic_Global =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
-        StatModifierHeroic_Health =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
-        StatModifierHeroic_Mana =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
-        StatModifierHeroic_Armor =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
-        StatModifierHeroic_Damage =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierHeroic_Global =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false), false); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifierHeroic_Health =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false), false); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifierHeroic_Mana =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false), false); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifierHeroic_Armor =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false), false); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifierHeroic_Damage =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false), false); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierHeroic_CCDuration =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.CCDuration", -1.0f, false);
 
-        StatModifierHeroic_Boss_Global =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
-        StatModifierHeroic_Boss_Health =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
-        StatModifierHeroic_Boss_Mana =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
-        StatModifierHeroic_Boss_Armor =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
-        StatModifierHeroic_Boss_Damage =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierHeroic_Boss_Global =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false), false); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifierHeroic_Boss_Health =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false), false); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifierHeroic_Boss_Mana =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false), false); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifierHeroic_Boss_Armor =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false), false); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifierHeroic_Boss_Damage =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false), false); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierHeroic_Boss_CCDuration =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.CCDuration", -1.0f, false);
 
         // Default for all raids
-        StatModifierRaid_Global =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
-        StatModifierRaid_Health =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
-        StatModifierRaid_Mana =                     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
-        StatModifierRaid_Armor =                    sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
-        StatModifierRaid_Damage =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierRaid_Global =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false), false); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifierRaid_Health =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false), false); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifierRaid_Mana =                     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false), false); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifierRaid_Armor =                    sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false), false); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifierRaid_Damage =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false), false); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierRaid_CCDuration =               sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.CCDuration", -1.0f, false);
 
-        StatModifierRaid_Boss_Global =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
-        StatModifierRaid_Boss_Health =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
-        StatModifierRaid_Boss_Mana =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
-        StatModifierRaid_Boss_Armor =               sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
-        StatModifierRaid_Boss_Damage =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierRaid_Boss_Global =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false), false); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifierRaid_Boss_Health =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false), false); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifierRaid_Boss_Mana =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false), false); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifierRaid_Boss_Armor =               sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false), false); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifierRaid_Boss_Damage =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false), false); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierRaid_Boss_CCDuration =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.CCDuration", -1.0f, false);
 
         // Default for all heroic raids
-        StatModifierRaidHeroic_Global =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
-        StatModifierRaidHeroic_Health =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
-        StatModifierRaidHeroic_Mana =               sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
-        StatModifierRaidHeroic_Armor =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
-        StatModifierRaidHeroic_Damage =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierRaidHeroic_Global =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false), false); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifierRaidHeroic_Health =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false), false); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifierRaidHeroic_Mana =               sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false), false); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifierRaidHeroic_Armor =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false), false); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifierRaidHeroic_Damage =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false), false); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierRaidHeroic_CCDuration =         sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.CCDuration", -1.0f, false);
 
-        StatModifierRaidHeroic_Boss_Global =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
-        StatModifierRaidHeroic_Boss_Health =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
-        StatModifierRaidHeroic_Boss_Mana =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
-        StatModifierRaidHeroic_Boss_Armor =         sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
-        StatModifierRaidHeroic_Boss_Damage =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierRaidHeroic_Boss_Global =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false), false); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifierRaidHeroic_Boss_Health =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false), false); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifierRaidHeroic_Boss_Mana =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false), false); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifierRaidHeroic_Boss_Armor =         sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false), false); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifierRaidHeroic_Boss_Damage =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false), false); // `AutoBalance.rate.damage` for backwards compatibility
+        StatModifierRaidHeroic_Boss_CCDuration =    sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.CCDuration", -1.0f, false);
 
         // 10-player raids
         StatModifierRaid10M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Global", StatModifierRaid_Global, false);
@@ -596,12 +608,14 @@ class AutoBalance_WorldScript : public WorldScript
         StatModifierRaid10M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Mana", StatModifierRaid_Mana, false);
         StatModifierRaid10M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Armor", StatModifierRaid_Armor, false);
         StatModifierRaid10M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Damage", StatModifierRaid_Damage, false);
+        StatModifierRaid10M_CCDuration =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.CCDuration", StatModifierRaid_CCDuration, false);
 
         StatModifierRaid10M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Global", StatModifierRaid_Boss_Global, false);
         StatModifierRaid10M_Boss_Health =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Health", StatModifierRaid_Boss_Health, false);
         StatModifierRaid10M_Boss_Mana =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Mana", StatModifierRaid_Boss_Mana, false);
         StatModifierRaid10M_Boss_Armor =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Armor", StatModifierRaid_Boss_Armor, false);
         StatModifierRaid10M_Boss_Damage =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Damage", StatModifierRaid_Boss_Damage, false);
+        StatModifierRaid10M_Boss_CCDuration =       sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.CCDuration", StatModifierRaid_Boss_CCDuration, false);
 
         // 10-player heroic raids
         StatModifierRaid10MHeroic_Global =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Global", StatModifierRaidHeroic_Global, false);
@@ -609,12 +623,14 @@ class AutoBalance_WorldScript : public WorldScript
         StatModifierRaid10MHeroic_Mana =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Mana", StatModifierRaidHeroic_Mana, false);
         StatModifierRaid10MHeroic_Armor =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Armor", StatModifierRaidHeroic_Armor, false);
         StatModifierRaid10MHeroic_Damage =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Damage", StatModifierRaidHeroic_Damage, false);
+        StatModifierRaid10MHeroic_CCDuration =      sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.CCDuration", StatModifierRaidHeroic_CCDuration, false);
 
         StatModifierRaid10MHeroic_Boss_Global =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Global", StatModifierRaidHeroic_Boss_Global, false);
         StatModifierRaid10MHeroic_Boss_Health =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Health", StatModifierRaidHeroic_Boss_Health, false);
         StatModifierRaid10MHeroic_Boss_Mana =       sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Mana", StatModifierRaidHeroic_Boss_Mana, false);
         StatModifierRaid10MHeroic_Boss_Armor =      sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Armor", StatModifierRaidHeroic_Boss_Armor, false);
         StatModifierRaid10MHeroic_Boss_Damage =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Damage", StatModifierRaidHeroic_Boss_Damage, false);
+        StatModifierRaid10MHeroic_Boss_CCDuration = sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.CCDuration", StatModifierRaidHeroic_Boss_CCDuration, false);
 
         // 15-player raids
         StatModifierRaid15M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Global", StatModifierRaid_Global, false);
@@ -622,12 +638,14 @@ class AutoBalance_WorldScript : public WorldScript
         StatModifierRaid15M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Mana", StatModifierRaid_Mana, false);
         StatModifierRaid15M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Armor", StatModifierRaid_Armor, false);
         StatModifierRaid15M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Damage", StatModifierRaid_Damage, false);
+        StatModifierRaid15M_CCDuration =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.CCDuration", StatModifierRaid_CCDuration, false);
 
         StatModifierRaid15M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Global", StatModifierRaid_Boss_Global, false);
         StatModifierRaid15M_Boss_Health =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Health", StatModifierRaid_Boss_Health, false);
         StatModifierRaid15M_Boss_Mana =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Mana", StatModifierRaid_Boss_Mana, false);
         StatModifierRaid15M_Boss_Armor =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Armor", StatModifierRaid_Boss_Armor, false);
         StatModifierRaid15M_Boss_Damage =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Damage", StatModifierRaid_Boss_Damage, false);
+        StatModifierRaid15M_Boss_CCDuration =       sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.CCDuration", StatModifierRaid_Boss_CCDuration, false);
 
         // 20-player raids
         StatModifierRaid20M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Global", StatModifierRaid_Global, false);
@@ -635,12 +653,14 @@ class AutoBalance_WorldScript : public WorldScript
         StatModifierRaid20M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Mana", StatModifierRaid_Mana, false);
         StatModifierRaid20M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Armor", StatModifierRaid_Armor, false);
         StatModifierRaid20M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Damage", StatModifierRaid_Damage, false);
+        StatModifierRaid20M_CCDuration =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.CCDuration", StatModifierRaid_CCDuration, false);
 
         StatModifierRaid20M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Global", StatModifierRaid_Boss_Global, false);
         StatModifierRaid20M_Boss_Health =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Health", StatModifierRaid_Boss_Health, false);
         StatModifierRaid20M_Boss_Mana =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Mana", StatModifierRaid_Boss_Mana, false);
         StatModifierRaid20M_Boss_Armor =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Armor", StatModifierRaid_Boss_Armor, false);
         StatModifierRaid20M_Boss_Damage =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Damage", StatModifierRaid_Boss_Damage, false);
+        StatModifierRaid20M_Boss_CCDuration =       sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.CCDuration", StatModifierRaid_Boss_CCDuration, false);
 
         // 25-player raids
         StatModifierRaid25M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Global", StatModifierRaid_Global, false);
@@ -648,12 +668,14 @@ class AutoBalance_WorldScript : public WorldScript
         StatModifierRaid25M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Mana", StatModifierRaid_Mana, false);
         StatModifierRaid25M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Armor", StatModifierRaid_Armor, false);
         StatModifierRaid25M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Damage", StatModifierRaid_Damage, false);
+        StatModifierRaid25M_CCDuration =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.CCDuration", StatModifierRaid_CCDuration, false);
 
         StatModifierRaid25M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Global", StatModifierRaid_Boss_Global, false);
         StatModifierRaid25M_Boss_Health =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Health", StatModifierRaid_Boss_Health, false);
         StatModifierRaid25M_Boss_Mana =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Mana", StatModifierRaid_Boss_Mana, false);
         StatModifierRaid25M_Boss_Armor =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Armor", StatModifierRaid_Boss_Armor, false);
         StatModifierRaid25M_Boss_Damage =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Damage", StatModifierRaid_Boss_Damage, false);
+        StatModifierRaid25M_Boss_CCDuration =       sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.CCDuration", StatModifierRaid_Boss_CCDuration, false);
 
         // 25-player heroic raids
         StatModifierRaid25MHeroic_Global =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Global", StatModifierRaidHeroic_Global, false);
@@ -661,12 +683,14 @@ class AutoBalance_WorldScript : public WorldScript
         StatModifierRaid25MHeroic_Mana =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Mana", StatModifierRaidHeroic_Mana, false);
         StatModifierRaid25MHeroic_Armor =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Armor", StatModifierRaidHeroic_Armor, false);
         StatModifierRaid25MHeroic_Damage =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Damage", StatModifierRaidHeroic_Damage, false);
+        StatModifierRaid25MHeroic_CCDuration =      sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.CCDuration", StatModifierRaidHeroic_CCDuration, false);
 
         StatModifierRaid25MHeroic_Boss_Global =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Global", StatModifierRaidHeroic_Boss_Global, false);
         StatModifierRaid25MHeroic_Boss_Health =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Health", StatModifierRaidHeroic_Boss_Health, false);
         StatModifierRaid25MHeroic_Boss_Mana =       sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Mana", StatModifierRaidHeroic_Boss_Mana, false);
         StatModifierRaid25MHeroic_Boss_Armor =      sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Armor", StatModifierRaidHeroic_Boss_Armor, false);
         StatModifierRaid25MHeroic_Boss_Damage =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Damage", StatModifierRaidHeroic_Boss_Damage, false);
+        StatModifierRaid25MHeroic_Boss_CCDuration = sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.CCDuration", StatModifierRaidHeroic_Boss_CCDuration, false);
 
         // 40-player raids
         StatModifierRaid40M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Global", StatModifierRaid_Global, false);
@@ -674,17 +698,21 @@ class AutoBalance_WorldScript : public WorldScript
         StatModifierRaid40M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Mana", StatModifierRaid_Mana, false);
         StatModifierRaid40M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Armor", StatModifierRaid_Armor, false);
         StatModifierRaid40M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Damage", StatModifierRaid_Damage, false);
+        StatModifierRaid40M_CCDuration =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.CCDuration", StatModifierRaid_CCDuration, false);
 
         StatModifierRaid40M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Global", StatModifierRaid_Boss_Global, false);
         StatModifierRaid40M_Boss_Health =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Health", StatModifierRaid_Boss_Health, false);
         StatModifierRaid40M_Boss_Mana =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Mana", StatModifierRaid_Boss_Mana, false);
         StatModifierRaid40M_Boss_Armor =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Armor", StatModifierRaid_Boss_Armor, false);
         StatModifierRaid40M_Boss_Damage =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Damage", StatModifierRaid_Boss_Damage, false);
+        StatModifierRaid40M_Boss_CCDuration =       sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.CCDuration", StatModifierRaid_Boss_CCDuration, false);
 
-        // Modifier Minimums
+        // Modifier Min/Max
         MinHPModifier = sConfigMgr->GetOption<float>("AutoBalance.MinHPModifier", 0.1f);
         MinManaModifier = sConfigMgr->GetOption<float>("AutoBalance.MinManaModifier", 0.01f);
         MinDamageModifier = sConfigMgr->GetOption<float>("AutoBalance.MinDamageModifier", 0.01f);
+        MinCCDurationModifier = sConfigMgr->GetOption<float>("AutoBalance.MinCCDurationModifier", 0.25f);
+        MaxCCDurationModifier = sConfigMgr->GetOption<float>("AutoBalance.MaxCCDurationModifier", 1.0f);
     }
 };
 
@@ -779,10 +807,16 @@ class AutoBalance_UnitScript : public UnitScript
         damage = _Modifer_DealDamage(target, attacker, damage);
     }
 
-    void ModifyHealReceived(Unit* target, Unit* attacker, uint32& damage, SpellInfo const* /*spellInfo*/) override {
+    void ModifyHealReceived(Unit* target, Unit* attacker, uint32& damage, SpellInfo const* /*spellInfo*/) override
+    {
         damage = _Modifer_DealDamage(target, attacker, damage);
     }
 
+    void OnAuraApply(Unit* unit, Aura* aura) override {
+        uint32 auraDuration = _Modifier_CCDuration(unit, aura->GetCaster(), aura);
+        aura->SetMaxDuration(auraDuration);
+        aura->SetDuration(auraDuration);
+    }
 
     uint32 _Modifer_DealDamage(Unit* target, Unit* attacker, uint32 damage)
     {
@@ -807,6 +841,49 @@ class AutoBalance_UnitScript : public UnitScript
             return damage;
 
         return damage * damageMultiplier;
+    }
+
+    uint32 _Modifier_CCDuration(Unit* target, Unit* caster, Aura* aura)
+    {
+        float originalDuration = (float)aura->GetDuration();
+
+        // only if enabled
+        if (!enabled)
+            return originalDuration;
+
+        // if the target isn't a player or the caster is a player, return the original duration
+        if (!target->IsPlayer() || caster->IsPlayer())
+            return originalDuration;
+
+        // if DungeonsOnly is set and we're not in a dungeon, return the original duration
+        if (!(!DungeonsOnly
+                || (target->GetMap()->IsDungeon() && caster->GetMap()->IsDungeon()) || (caster->GetMap()->IsBattleground()
+                     && target->GetMap()->IsBattleground())))
+            return originalDuration;
+
+        // if the aura was cast by a pet or summon, return the original duration
+        if ((caster->IsHunterPet() || caster->IsPet() || caster->IsSummon()) && caster->IsControlledByPlayer())
+            return originalDuration;
+
+        // only if this aura is a CC
+        if (
+            aura->HasEffectType(SPELL_AURA_MOD_CHARM)          ||
+            aura->HasEffectType(SPELL_AURA_MOD_CONFUSE)        ||
+            aura->HasEffectType(SPELL_AURA_MOD_DISARM)         ||
+            aura->HasEffectType(SPELL_AURA_MOD_FEAR)           ||
+            aura->HasEffectType(SPELL_AURA_MOD_PACIFY)         ||
+            aura->HasEffectType(SPELL_AURA_MOD_POSSESS)        ||
+            aura->HasEffectType(SPELL_AURA_MOD_SILENCE)        ||
+            aura->HasEffectType(SPELL_AURA_MOD_STUN)           ||
+            aura->HasEffectType(SPELL_AURA_MOD_SPEED_SLOW_ALL)
+            )
+        {
+            return originalDuration * (float)caster->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->CCDurationMultiplier;
+        }
+        else
+        {
+            return originalDuration;
+        }
     }
 };
 
@@ -1282,8 +1359,8 @@ public:
         //
 
         // Calculate stat modifiers
-        float statMod_global, statMod_health, statMod_mana, statMod_armor, statMod_damage;
-        float statMod_boss_global, statMod_boss_health, statMod_boss_mana, statMod_boss_armor, statMod_boss_damage;
+        float statMod_global, statMod_health, statMod_mana, statMod_armor, statMod_damage, statMod_ccDuration;
+        float statMod_boss_global, statMod_boss_health, statMod_boss_mana, statMod_boss_armor, statMod_boss_damage, statMod_boss_ccDuration;
 
         // Apply the per-instance-type modifiers first
 		if (instanceMap->IsHeroic())
@@ -1296,11 +1373,14 @@ public:
 			        statMod_mana = StatModifierHeroic_Mana;
 			        statMod_armor = StatModifierHeroic_Armor;
 			        statMod_damage = StatModifierHeroic_Damage;
+			        statMod_ccDuration = StatModifierHeroic_CCDuration;
+
 			        statMod_boss_global = StatModifierHeroic_Boss_Global;
 			        statMod_boss_health = StatModifierHeroic_Boss_Health;
 			        statMod_boss_mana = StatModifierHeroic_Boss_Mana;
 			        statMod_boss_armor = StatModifierHeroic_Boss_Armor;
 			        statMod_boss_damage = StatModifierHeroic_Boss_Damage;
+			        statMod_boss_ccDuration = StatModifierHeroic_Boss_CCDuration;
 			        break;
 			    case 10:
                     statMod_global = StatModifierRaid10MHeroic_Global;
@@ -1308,11 +1388,14 @@ public:
                     statMod_mana = StatModifierRaid10MHeroic_Mana;
                     statMod_armor = StatModifierRaid10MHeroic_Armor;
                     statMod_damage = StatModifierRaid10MHeroic_Damage;
+                    statMod_ccDuration = StatModifierRaid10MHeroic_CCDuration;
+
                     statMod_boss_global = StatModifierRaid10MHeroic_Boss_Global;
                     statMod_boss_health = StatModifierRaid10MHeroic_Boss_Health;
                     statMod_boss_mana = StatModifierRaid10MHeroic_Boss_Mana;
                     statMod_boss_armor = StatModifierRaid10MHeroic_Boss_Armor;
                     statMod_boss_damage = StatModifierRaid10MHeroic_Boss_Damage;
+                    statMod_boss_ccDuration = StatModifierRaid10MHeroic_Boss_CCDuration;
 			        break;
 			    case 25:
                     statMod_global = StatModifierRaid25MHeroic_Global;
@@ -1320,11 +1403,14 @@ public:
                     statMod_mana = StatModifierRaid25MHeroic_Mana;
                     statMod_armor = StatModifierRaid25MHeroic_Armor;
                     statMod_damage = StatModifierRaid25MHeroic_Damage;
+                    statMod_ccDuration = StatModifierRaid25MHeroic_CCDuration;
+
                     statMod_boss_global = StatModifierRaid25MHeroic_Boss_Global;
                     statMod_boss_health = StatModifierRaid25MHeroic_Boss_Health;
                     statMod_boss_mana = StatModifierRaid25MHeroic_Boss_Mana;
                     statMod_boss_armor = StatModifierRaid25MHeroic_Boss_Armor;
                     statMod_boss_damage = StatModifierRaid25MHeroic_Boss_Damage;
+                    statMod_boss_ccDuration = StatModifierRaid25MHeroic_Boss_CCDuration;
                     break;
 			    default:
                     statMod_global = StatModifierRaidHeroic_Global;
@@ -1332,11 +1418,14 @@ public:
                     statMod_mana = StatModifierRaidHeroic_Mana;
                     statMod_armor = StatModifierRaidHeroic_Armor;
                     statMod_damage = StatModifierRaidHeroic_Damage;
+                    statMod_ccDuration = StatModifierRaidHeroic_CCDuration;
+
                     statMod_boss_global = StatModifierRaidHeroic_Global;
                     statMod_boss_health = StatModifierRaidHeroic_Health;
                     statMod_boss_mana = StatModifierRaidHeroic_Mana;
                     statMod_boss_armor = StatModifierRaidHeroic_Armor;
                     statMod_boss_damage = StatModifierRaidHeroic_Damage;
+                    statMod_boss_ccDuration = StatModifierRaidHeroic_Boss_CCDuration;
 			}
 		}
 		else
@@ -1349,11 +1438,14 @@ public:
 			        statMod_mana = StatModifier_Mana;
 			        statMod_armor = StatModifier_Armor;
 			        statMod_damage = StatModifier_Damage;
+			        statMod_ccDuration = StatModifier_CCDuration;
+
 			        statMod_boss_global = StatModifier_Boss_Global;
 			        statMod_boss_health = StatModifier_Boss_Health;
 			        statMod_boss_mana = StatModifier_Boss_Mana;
 			        statMod_boss_armor = StatModifier_Boss_Armor;
 			        statMod_boss_damage = StatModifier_Boss_Damage;
+			        statMod_boss_ccDuration = StatModifier_Boss_CCDuration;
 			        break;
 			    case 10:
                     statMod_global = StatModifierRaid10M_Global;
@@ -1361,11 +1453,14 @@ public:
                     statMod_mana = StatModifierRaid10M_Mana;
                     statMod_armor = StatModifierRaid10M_Armor;
                     statMod_damage = StatModifierRaid10M_Damage;
+                    statMod_ccDuration = StatModifierRaid10M_CCDuration;
+
                     statMod_boss_global = StatModifierRaid10M_Boss_Global;
                     statMod_boss_health = StatModifierRaid10M_Boss_Health;
                     statMod_boss_mana = StatModifierRaid10M_Boss_Mana;
                     statMod_boss_armor = StatModifierRaid10M_Boss_Armor;
                     statMod_boss_damage = StatModifierRaid10M_Boss_Damage;
+                    statMod_boss_ccDuration = StatModifierRaid10M_Boss_CCDuration;
                     break;
 			    case 15:
                     statMod_global = StatModifierRaid15M_Global;
@@ -1373,11 +1468,14 @@ public:
                     statMod_mana = StatModifierRaid15M_Mana;
                     statMod_armor = StatModifierRaid15M_Armor;
                     statMod_damage = StatModifierRaid15M_Damage;
+                    statMod_ccDuration = StatModifierRaid15M_CCDuration;
+
                     statMod_boss_global = StatModifierRaid15M_Boss_Global;
                     statMod_boss_health = StatModifierRaid15M_Boss_Health;
                     statMod_boss_mana = StatModifierRaid15M_Boss_Mana;
                     statMod_boss_armor = StatModifierRaid15M_Boss_Armor;
                     statMod_boss_damage = StatModifierRaid15M_Boss_Damage;
+                    statMod_boss_ccDuration = StatModifierRaid15M_Boss_CCDuration;
                     break;
 			    case 20:
                     statMod_global = StatModifierRaid20M_Global;
@@ -1385,11 +1483,14 @@ public:
                     statMod_mana = StatModifierRaid20M_Mana;
                     statMod_armor = StatModifierRaid20M_Armor;
                     statMod_damage = StatModifierRaid20M_Damage;
+                    statMod_ccDuration = StatModifierRaid20M_CCDuration;
+
                     statMod_boss_global = StatModifierRaid20M_Boss_Global;
                     statMod_boss_health = StatModifierRaid20M_Boss_Health;
                     statMod_boss_mana = StatModifierRaid20M_Boss_Mana;
                     statMod_boss_armor = StatModifierRaid20M_Boss_Armor;
                     statMod_boss_damage = StatModifierRaid20M_Boss_Damage;
+                    statMod_boss_ccDuration = StatModifierRaid20M_Boss_CCDuration;
                     break;
 			    case 25:
                     statMod_global = StatModifierRaid25M_Global;
@@ -1397,11 +1498,14 @@ public:
                     statMod_mana = StatModifierRaid25M_Mana;
                     statMod_armor = StatModifierRaid25M_Armor;
                     statMod_damage = StatModifierRaid25M_Damage;
+                    statMod_ccDuration = StatModifierRaid25M_CCDuration;
+
                     statMod_boss_global = StatModifierRaid25M_Boss_Global;
                     statMod_boss_health = StatModifierRaid25M_Boss_Health;
                     statMod_boss_mana = StatModifierRaid25M_Boss_Mana;
                     statMod_boss_armor = StatModifierRaid25M_Boss_Armor;
                     statMod_boss_damage = StatModifierRaid25M_Boss_Damage;
+                    statMod_boss_ccDuration = StatModifierRaid25M_Boss_CCDuration;
                     break;
 			    case 40:
                     statMod_global = StatModifierRaid40M_Global;
@@ -1409,11 +1513,14 @@ public:
                     statMod_mana = StatModifierRaid40M_Mana;
                     statMod_armor = StatModifierRaid40M_Armor;
                     statMod_damage = StatModifierRaid40M_Damage;
+                    statMod_ccDuration = StatModifierRaid40M_CCDuration;
+
                     statMod_boss_global = StatModifierRaid40M_Boss_Global;
                     statMod_boss_health = StatModifierRaid40M_Boss_Health;
                     statMod_boss_mana = StatModifierRaid40M_Boss_Mana;
                     statMod_boss_armor = StatModifierRaid40M_Boss_Armor;
                     statMod_boss_damage = StatModifierRaid40M_Boss_Damage;
+                    statMod_boss_ccDuration = StatModifierRaid40M_Boss_CCDuration;
                     break;
 			    default:
                     statMod_global = StatModifierRaid_Global;
@@ -1421,11 +1528,14 @@ public:
                     statMod_mana = StatModifierRaid_Mana;
                     statMod_armor = StatModifierRaid_Armor;
                     statMod_damage = StatModifierRaid_Damage;
+                    statMod_ccDuration = StatModifierRaid_CCDuration;
+
                     statMod_boss_global = StatModifierRaid_Boss_Global;
                     statMod_boss_health = StatModifierRaid_Boss_Health;
                     statMod_boss_mana = StatModifierRaid_Boss_Mana;
                     statMod_boss_armor = StatModifierRaid_Boss_Armor;
                     statMod_boss_damage = StatModifierRaid_Boss_Damage;
+                    statMod_boss_ccDuration = StatModifierRaid_Boss_CCDuration;
 			}
 		}
 
@@ -1441,6 +1551,7 @@ public:
                 statMod_mana = statMod_boss_mana;
                 statMod_armor = statMod_boss_armor;
                 statMod_damage = statMod_boss_damage;
+                statMod_ccDuration = statMod_boss_ccDuration;
             }
 
             // Per-instance boss overrides
@@ -1454,6 +1565,7 @@ public:
                 if (myStatModifierBossOverrides->mana != -1)        { statMod_mana =        myStatModifierBossOverrides->mana;        }
                 if (myStatModifierBossOverrides->armor != -1)       { statMod_armor =       myStatModifierBossOverrides->armor;       }
                 if (myStatModifierBossOverrides->damage != -1)      { statMod_damage =      myStatModifierBossOverrides->damage;      }
+                if (myStatModifierBossOverrides->ccduration != -1)  { statMod_ccDuration =  myStatModifierBossOverrides->ccduration;  }
             }
         }
         // Non-boss modifiers
@@ -1470,6 +1582,7 @@ public:
                 if (myStatModifierOverrides->mana != -1)        { statMod_mana =        myStatModifierOverrides->mana;        }
                 if (myStatModifierOverrides->armor != -1)       { statMod_armor =       myStatModifierOverrides->armor;       }
                 if (myStatModifierOverrides->damage != -1)      { statMod_damage =      myStatModifierOverrides->damage;      }
+                if (myStatModifierOverrides->ccduration != -1)  { statMod_ccDuration =  myStatModifierOverrides->ccduration;  }
             }
         }
 
@@ -1484,6 +1597,7 @@ public:
             if (myCreatureOverrides->mana != -1)        { statMod_mana =        myCreatureOverrides->mana;        }
             if (myCreatureOverrides->armor != -1)       { statMod_armor =       myCreatureOverrides->armor;       }
             if (myCreatureOverrides->damage != -1)      { statMod_damage =      myCreatureOverrides->damage;      }
+            if (myCreatureOverrides->ccduration != -1)  { statMod_ccDuration =  myCreatureOverrides->ccduration;  }
         }
 
         // #maththings 
@@ -1600,6 +1714,29 @@ public:
         }
 
         //
+        // Crowd Control Debuff Duration Scaling
+        //
+        float ccDurationMul;
+        if (statMod_ccDuration != -1.0f)
+        {
+            ccDurationMul = defaultMultiplier * statMod_ccDuration;
+
+            // Min/Max checking
+            if (ccDurationMul < MinCCDurationModifier)
+            {
+                ccDurationMul = MinCCDurationModifier;
+            }
+            else if (ccDurationMul > MaxCCDurationModifier)
+            {
+                ccDurationMul = MaxCCDurationModifier;
+            }
+        }
+        else
+        {
+            ccDurationMul = 1.0f;
+        }
+
+        //
         //  Apply New Values
         //
         if (!sABScriptMgr->OnBeforeUpdateStats(creature, scaledHealth, scaledMana, damageMul, newBaseArmor))
@@ -1624,6 +1761,7 @@ public:
         creature->SetModifierValue(UNIT_MOD_HEALTH, BASE_VALUE, (float)scaledHealth);
         creature->SetModifierValue(UNIT_MOD_MANA, BASE_VALUE, (float)scaledMana);
         creatureABInfo->DamageMultiplier = damageMul;
+        creatureABInfo->CCDurationMultiplier = ccDurationMul;
 
         uint32 scaledCurHealth=prevHealth && prevMaxHealth ? float(scaledHealth)/float(prevMaxHealth)*float(prevHealth) : 0;
         uint32 scaledCurPower=prevPower && prevMaxPower  ? float(scaledMana)/float(prevMaxPower)*float(prevPower) : 0;
@@ -1769,6 +1907,7 @@ public:
         handler->PSendSysMessage("Mana multiplier: %.6f", creatureABInfo->ManaMultiplier);
         handler->PSendSysMessage("Armor multiplier: %.6f", creatureABInfo->ArmorMultiplier);
         handler->PSendSysMessage("Damage multiplier: %.6f", creatureABInfo->DamageMultiplier);
+        handler->PSendSysMessage("CC Duration multiplier: %.6f", creatureABInfo->CCDurationMultiplier);
 
         return true;
 

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -143,8 +143,21 @@ static std::map<uint32, float> bossOverrides;
 static int8 PlayerCountDifficultyOffset, LevelScaling, higherOffset, lowerOffset;
 static uint32 rewardRaid, rewardDungeon, MinPlayerReward;
 static bool enabled, LevelEndGameBoost, DungeonsOnly, PlayerChangeNotify, LevelUseDb, rewardEnabled, DungeonScaleDownXP, DungeonScaleDownMoney;
-static float globalRate, healthMultiplier, manaMultiplier, armorMultiplier, damageMultiplier, MinHPModifier, MinManaModifier, MinDamageModifier,
-InflectionPoint, InflectionPointRaid, InflectionPointRaid10M, InflectionPointRaid25M, InflectionPointHeroic, InflectionPointRaidHeroic, InflectionPointRaid10MHeroic, InflectionPointRaid25MHeroic, BossInflectionMult;
+static float globalRate, healthMultiplier, manaMultiplier, armorMultiplier, damageMultiplier, MinHPModifier, MinManaModifier, MinDamageModifier;
+
+static float InflectionPoint, InflectionPointCurveFloor, InflectionPointCurveCeiling, InflectionPointBoss;
+static float InflectionPointHeroic, InflectionPointHeroicCurveFloor, InflectionPointHeroicCurveCeiling, InflectionPointHeroicBoss;
+static float InflectionPointRaid, InflectionPointRaidCurveFloor, InflectionPointRaidCurveCeiling, InflectionPointRaidBoss;
+static float InflectionPointRaidHeroic, InflectionPointRaidHeroicCurveFloor, InflectionPointRaidHeroicCurveCeiling, InflectionPointRaidHeroicBoss;
+
+static float InflectionPointRaid10M, InflectionPointRaid10MCurveFloor, InflectionPointRaid10MCurveCeiling, InflectionPointRaid10MBoss;
+static float InflectionPointRaid10MHeroic, InflectionPointRaid10MHeroicCurveFloor, InflectionPointRaid10MHeroicCurveCeiling, InflectionPointRaid10MHeroicBoss;
+static float InflectionPointRaid15M, InflectionPointRaid15MCurveFloor, InflectionPointRaid15MCurveCeiling, InflectionPointRaid15MBoss;
+static float InflectionPointRaid20M, InflectionPointRaid20MCurveFloor, InflectionPointRaid20MCurveCeiling, InflectionPointRaid20MBoss;
+static float InflectionPointRaid25M, InflectionPointRaid25MCurveFloor, InflectionPointRaid25MCurveCeiling, InflectionPointRaid25MBoss;
+static float InflectionPointRaid25MHeroic, InflectionPointRaid25MHeroicCurveFloor, InflectionPointRaid25MHeroicCurveCeiling, InflectionPointRaid25MHeroicBoss;
+static float InflectionPointRaid40M, InflectionPointRaid40MCurveFloor, InflectionPointRaid40MCurveCeiling, InflectionPointRaid40MBoss;
+
 
 int GetValidDebugLevel()
 {
@@ -322,22 +335,68 @@ class AutoBalance_WorldScript : public WorldScript
         MinPlayerReward = sConfigMgr->GetOption<float>("AutoBalance.reward.MinPlayerReward", 1);
 
         InflectionPoint = sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint", 0.5f);
-        InflectionPointRaid = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid", InflectionPoint);
-        InflectionPointRaid25M = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid25M", InflectionPointRaid);
-        InflectionPointRaid10M = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10M", InflectionPointRaid);
-        InflectionPointHeroic = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic", InflectionPoint);
-        InflectionPointRaidHeroic = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic", InflectionPointRaid);
-        InflectionPointRaid25MHeroic = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid25MHeroic", InflectionPointRaid25M);
-        InflectionPointRaid10MHeroic = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10MHeroic", InflectionPointRaid10M);
-        BossInflectionMult = sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f);
+        InflectionPointCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint.CurveFloor", 0.0f);
+        InflectionPointCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint.CurveCeiling", 1.0f);
+        InflectionPointBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPoint.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false)); // `AutoBalance.BossInflectionMult` for backwads compatibility
+
+        InflectionPointHeroic = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic", 0.5f);
+        InflectionPointHeroicCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic.CurveFloor", 0.0f);
+        InflectionPointHeroicCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic.CurveCeiling", 1.0f);
+        InflectionPointHeroicBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointHeroic.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false)); // `AutoBalance.BossInflectionMult` for backwads compatibility
+
+        InflectionPointRaid = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid", 0.5f);
+        InflectionPointRaidCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid.CurveFloor", 0.0f);
+        InflectionPointRaidCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid.CurveCeiling", 1.0f);
+        InflectionPointRaidBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false)); // `AutoBalance.BossInflectionMult` for backwads compatibility
+
+        InflectionPointRaidHeroic = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic", 0.5f);
+        InflectionPointRaidHeroicCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic.CurveFloor", 0.0f);
+        InflectionPointRaidHeroicCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic.CurveCeiling", 1.0f);
+        InflectionPointRaidHeroicBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaidHeroic.BossModifier", sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", 1.0f, false)); // `AutoBalance.BossInflectionMult` for backwads compatibility
+
+        InflectionPointRaid10M = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10M", InflectionPointRaid, false);
+        InflectionPointRaid10MCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10M.CurveFloor", InflectionPointRaidCurveFloor, false);
+        InflectionPointRaid10MCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10M.CurveCeiling", InflectionPointRaidCurveCeiling, false);
+        InflectionPointRaid10MBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10M.BossModifier", InflectionPointRaidBoss, false);
+
+        InflectionPointRaid10MHeroic = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10MHeroic", InflectionPointRaidHeroic, false);
+        InflectionPointRaid10MHeroicCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10MHeroic.CurveFloor", InflectionPointRaidHeroicCurveFloor, false);
+        InflectionPointRaid10MHeroicCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10MHeroic.CurveCeiling", InflectionPointRaidHeroicCurveCeiling, false);
+        InflectionPointRaid10MHeroicBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid10MHeroic.BossModifier", InflectionPointRaidHeroicBoss, false);
+
+        InflectionPointRaid15M = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid15M", InflectionPointRaid, false);
+        InflectionPointRaid15MCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid15M.CurveFloor", InflectionPointRaidCurveFloor, false);
+        InflectionPointRaid15MCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid15M.CurveCeiling", InflectionPointRaidCurveCeiling, false);
+        InflectionPointRaid15MBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid15M.BossModifier", InflectionPointRaidBoss, false);
+
+        InflectionPointRaid20M = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid20M", InflectionPointRaid, false);
+        InflectionPointRaid20MCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid20M.CurveFloor", InflectionPointRaidCurveFloor, false);
+        InflectionPointRaid20MCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid20M.CurveCeiling", InflectionPointRaidCurveCeiling, false);
+        InflectionPointRaid20MBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid20M.BossModifier", InflectionPointRaidBoss, false);
+
+        InflectionPointRaid25M = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid25M", InflectionPointRaid, false);
+        InflectionPointRaid25MCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid25M.CurveFloor", InflectionPointRaidCurveFloor, false);
+        InflectionPointRaid25MCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid25M.CurveCeiling", InflectionPointRaidCurveCeiling, false);
+        InflectionPointRaid25MBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid25M.BossModifier", InflectionPointRaidBoss, false);
+
+        InflectionPointRaid25MHeroic = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid25MHeroic", InflectionPointRaidHeroic, false);
+        InflectionPointRaid25MHeroicCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid25MHeroic.CurveFloor", InflectionPointRaidHeroicCurveFloor, false);
+        InflectionPointRaid25MHeroicCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid25MHeroic.CurveCeiling", InflectionPointRaidHeroicCurveCeiling, false);
+        InflectionPointRaid25MHeroicBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid25MHeroic.BossModifier", InflectionPointRaidHeroicBoss, false);
+
+        InflectionPointRaid40M = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid40M", InflectionPointRaid, false);
+        InflectionPointRaid40MCurveFloor = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid40M.CurveFloor", InflectionPointRaidCurveFloor, false);
+        InflectionPointRaid40MCurveCeiling = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid40M.CurveCeiling", InflectionPointRaidCurveCeiling, false);
+        InflectionPointRaid40MBoss = sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid40M.BossModifier", InflectionPointRaidBoss, false);
+
         globalRate = sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f);
         healthMultiplier = sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f);
         manaMultiplier = sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f);
         armorMultiplier = sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f);
         damageMultiplier = sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f);
         MinHPModifier = sConfigMgr->GetOption<float>("AutoBalance.MinHPModifier", 0.1f);
-        MinManaModifier = sConfigMgr->GetOption<float>("AutoBalance.MinManaModifier", 0.1f);
-        MinDamageModifier = sConfigMgr->GetOption<float>("AutoBalance.MinDamageModifier", 0.1f);
+        MinManaModifier = sConfigMgr->GetOption<float>("AutoBalance.MinManaModifier", 0.01f);
+        MinDamageModifier = sConfigMgr->GetOption<float>("AutoBalance.MinDamageModifier", 0.01f);
     }
 };
 
@@ -748,55 +807,115 @@ public:
         //       The +1 and /2 values raise the TanH function to a positive range and make
         //       sure the modifier never goes above the value or 1.0 or below 0.
         //
+        //       curveFloor and curveCeiling squishes the curve by adjusting the curve start and end points.
+        //       This allows for better control over high and low player count scaling.
+
         float defaultMultiplier = 1.0f;
-        if (creatureABInfo->instancePlayerCount < maxNumberOfPlayers)
+        float curveFloor = 0.0f;
+        float curveCeiling = 1.0f;
+        float bossMultiplier = 1.0f;
+
+        float inflectionValue  = (float)maxNumberOfPlayers;
+        if (hasDungeonOverride(mapId))
         {
-            float inflectionValue  = (float)maxNumberOfPlayers;
-            if (hasDungeonOverride(mapId))
+            inflectionValue *= dungeonOverrides[mapId];
+        }
+        else
+        {
+            if (instanceMap->IsHeroic())
             {
-                inflectionValue *= dungeonOverrides[mapId];
-            }
-            else
-            {
-                if (instanceMap->IsHeroic())
+                if (instanceMap->IsRaid())
                 {
-                    if (instanceMap->IsRaid())
+                    switch (instanceMap->GetMaxPlayers())
                     {
-                        switch (instanceMap->GetMaxPlayers())
-                        {
-                            case 10:
-                                inflectionValue *= InflectionPointRaid10MHeroic;
-                                break;
-                            case 25:
-                                inflectionValue *= InflectionPointRaid25MHeroic;
-                                break;
-                            default:
-                                inflectionValue *= InflectionPointRaidHeroic;
-                        }
+                        case 10:
+                            inflectionValue *= InflectionPointRaid10MHeroic;
+                            curveFloor = InflectionPointRaid10MHeroicCurveFloor;
+                            curveCeiling = InflectionPointRaid10MHeroicCurveCeiling;
+                            bossMultiplier = InflectionPointRaid10MHeroicBoss;
+                            break;
+                        case 25:
+                            inflectionValue *= InflectionPointRaid25MHeroic;
+                            curveFloor = InflectionPointRaid25MHeroicCurveFloor;
+                            curveCeiling = InflectionPointRaid25MHeroicCurveCeiling;
+                            bossMultiplier = InflectionPointRaid25MHeroic;
+                            break;
+                        default:
+                            inflectionValue *= InflectionPointRaidHeroic;
+                            curveFloor = InflectionPointRaidHeroicCurveFloor;
+                            curveCeiling = InflectionPointRaidHeroicCurveCeiling;
+                            bossMultiplier = InflectionPointRaidHeroic;
                     }
-                    else
-                        inflectionValue *= InflectionPointHeroic;
                 }
                 else
                 {
-                    if (instanceMap->IsRaid())
-                    {
-                        switch (instanceMap->GetMaxPlayers())
-                        {
-                            case 10:
-                                inflectionValue *= InflectionPointRaid10M;
-                                break;
-                            case 25:
-                                inflectionValue *= InflectionPointRaid25M;
-                                break;
-                            default:
-                                inflectionValue *= InflectionPointRaid;
-                        }
-                    }
-                    else
-                        inflectionValue *= InflectionPoint;
+                    inflectionValue *= InflectionPointHeroic;
+                    curveFloor = InflectionPointHeroicCurveFloor;
+                    curveCeiling = InflectionPointHeroicCurveCeiling;
+                    bossMultiplier = InflectionPointHeroicBoss;
                 }
             }
+            else
+            {
+                if (instanceMap->IsRaid())
+                {
+                    switch (instanceMap->GetMaxPlayers())
+                    {
+                        case 10:
+                            inflectionValue *= InflectionPointRaid10M;
+                            curveFloor = InflectionPointRaid10MCurveFloor;
+                            curveCeiling = InflectionPointRaid10MCurveCeiling;
+                            bossMultiplier = InflectionPointRaid10MBoss;
+                            break;
+                        case 15:
+                            inflectionValue *= InflectionPointRaid15M;
+                            curveFloor = InflectionPointRaid15MCurveFloor;
+                            curveCeiling = InflectionPointRaid15MCurveCeiling;
+                            bossMultiplier = InflectionPointRaid15MBoss;
+                            break;
+                        case 20:
+                            inflectionValue *= InflectionPointRaid20M;
+                            curveFloor = InflectionPointRaid20MCurveFloor;
+                            curveCeiling = InflectionPointRaid20MCurveCeiling;
+                            bossMultiplier = InflectionPointRaid20M;
+                            break;
+                        case 25:
+                            inflectionValue *= InflectionPointRaid25M;
+                            curveFloor = InflectionPointRaid25MCurveFloor;
+                            curveCeiling = InflectionPointRaid25MCurveCeiling;
+                            bossMultiplier = InflectionPointRaid25MBoss;
+                            break;
+                        case 40:
+                            inflectionValue *= InflectionPointRaid40M;
+                            curveFloor = InflectionPointRaid40MCurveFloor;
+                            curveCeiling = InflectionPointRaid40MCurveCeiling;
+                            bossMultiplier = InflectionPointRaid40M;
+                            break;
+                        default:
+                            inflectionValue *= InflectionPointRaid;
+                            curveFloor = InflectionPointRaidCurveFloor;
+                            curveCeiling = InflectionPointRaidCurveCeiling;
+                            bossMultiplier = InflectionPointRaid;
+                    }
+                }
+                else
+                {
+                    inflectionValue *= InflectionPoint;
+                    curveFloor = InflectionPointCurveFloor;
+                    curveCeiling = InflectionPointCurveCeiling;
+                    bossMultiplier = InflectionPointBoss;
+                }
+            }
+        }
+
+        if (creatureABInfo->instancePlayerCount >= maxNumberOfPlayers)
+        // We've maxed out the number of players, engage maximum difficulty!
+        {
+            defaultMultiplier = curveCeiling;
+        }
+        else
+        // Less than full instance, adjust accordingly
+        {
             if (creature->IsDungeonBoss()) {
                 if (hasBossOverride(mapId))
                 {
@@ -804,12 +923,15 @@ public:
                 }
                 else
                 {
-                    inflectionValue *= BossInflectionMult;
+                    inflectionValue *= bossMultiplier;
                 }
             }
 
             float diff = ((float)maxNumberOfPlayers/5)*1.5f;
             defaultMultiplier = (tanh(((float)creatureABInfo->instancePlayerCount - inflectionValue) / diff) + 1.0f) / 2.0f;
+
+            // Adjust the multiplier based on the configured floor and ceiling values
+            defaultMultiplier = (defaultMultiplier * (curveCeiling - curveFloor) + curveFloor);
         }
 
         if (!sABScriptMgr->OnAfterDefaultMultiplier(creature, defaultMultiplier))
@@ -953,15 +1075,16 @@ public:
         static std::vector<ChatCommand> ABCommandTable =
         {
             { "setoffset",        SEC_GAMEMASTER,                        true, &HandleABSetOffsetCommand,                 "Sets the global Player Difficulty Offset for instances. Example: (You + offset(1) = 2 player difficulty)." },
-            { "getoffset",        SEC_GAMEMASTER,                        true, &HandleABGetOffsetCommand,                 "Shows current global player offset value" },
+            { "getoffset",        SEC_GAMEMASTER,                        true, &HandleABGetOffsetCommand,                 "Shows current global player offset value." },
             { "checkmap",         SEC_GAMEMASTER,                        true, &HandleABCheckMapCommand,                  "Run a check for current map/instance, it can help in case you're testing autobalance with GM." },
-            { "mapstat",          SEC_GAMEMASTER,                        true, &HandleABMapStatsCommand,                  "Shows current autobalance information for this map-" },
+            { "mapstat",          SEC_GAMEMASTER,                        true, &HandleABMapStatsCommand,                  "Shows current autobalance information for this map" },
             { "creaturestat",     SEC_GAMEMASTER,                        true, &HandleABCreatureStatsCommand,             "Shows current autobalance information for selected creature." },
         };
 
         static std::vector<ChatCommand> commandTable =
         {
             { "autobalance",     SEC_GAMEMASTER,                            false, NULL,                      "", ABCommandTable },
+            { "ab",              SEC_GAMEMASTER,                            false, NULL,                      "", ABCommandTable },
         };
         return commandTable;
     }

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -546,7 +546,7 @@ class AutoBalance_WorldScript : public WorldScript
         StatModifier_Global =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false), false); // `AutoBalance.rate.global` for backwards compatibility
         StatModifier_Health =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false), false); // `AutoBalance.rate.health` for backwards compatibility
         StatModifier_Mana =                         sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false), false); // `AutoBalance.rate.mana` for backwards compatibility
-        StatModifier_Armor =                        sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)), false; // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifier_Armor =                        sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false), false); // `AutoBalance.rate.armor` for backwards compatibility
         StatModifier_Damage =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false), false); // `AutoBalance.rate.damage` for backwards compatibility
         StatModifier_CCDuration =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifier.CCDuration", -1.0f, false);
 
@@ -1201,7 +1201,11 @@ public:
         {
             switch (maxNumberOfPlayers)
             {
-                case 5:
+			    case 1:
+			    case 2:
+			    case 3:
+			    case 4:
+			    case 5:
                     inflectionValue *= InflectionPointHeroic;
                     curveFloor = InflectionPointHeroicCurveFloor;
                     curveCeiling = InflectionPointHeroicCurveCeiling;
@@ -1226,7 +1230,11 @@ public:
         {
             switch (maxNumberOfPlayers)
             {
-                case 5:
+			    case 1:
+			    case 2:
+			    case 3:
+			    case 4:
+			    case 5:
                     inflectionValue *= InflectionPoint;
                     curveFloor = InflectionPointCurveFloor;
                     curveCeiling = InflectionPointCurveCeiling;
@@ -1291,7 +1299,11 @@ public:
             {
                 switch (maxNumberOfPlayers)
                 {
-                    case 5:
+			        case 1:
+			        case 2:
+			        case 3:
+			        case 4:
+			        case 5:
                         bossInflectionPointMultiplier = InflectionPointHeroicBoss;
                         break;
                     case 10:
@@ -1308,7 +1320,11 @@ public:
             {
                 switch (maxNumberOfPlayers)
                 {
-                    case 5:
+			        case 1:
+			        case 2:
+			        case 3:
+			        case 4:
+			        case 5:
                         bossInflectionPointMultiplier = InflectionPointBoss;
                         break;
                     case 10:
@@ -1367,6 +1383,10 @@ public:
 		{
 			switch (maxNumberOfPlayers)
 			{
+			    case 1:
+			    case 2:
+			    case 3:
+			    case 4:
 			    case 5:
 			        statMod_global = StatModifierHeroic_Global;
 			        statMod_health = StatModifierHeroic_Health;
@@ -1432,6 +1452,10 @@ public:
 		{
 			switch (maxNumberOfPlayers)
 			{
+			    case 1:
+			    case 2:
+			    case 3:
+			    case 4:
 			    case 5:
 			        statMod_global = StatModifier_Global;
 			        statMod_health = StatModifier_Health;

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -961,7 +961,7 @@ public:
         // avoid level changing for critters and special creatures (spell summons etc.) in instances
         bool skipLevel=false;
         if (originalLevel <= 1 && areaMinLvl >= 5)
-            skipLevel = true;
+            return;
 
         if (LevelScaling && creature->GetMap()->IsDungeon() && !skipLevel && !checkLevelOffset(level, originalLevel)) {  // change level only whithin the offsets and when in dungeon/raid
             if (level != creatureABInfo->selectedLevel || creatureABInfo->selectedLevel != creature->getLevel()) {

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -138,7 +138,7 @@ class AutoBalanceStatModifiers : public DataMap::Base
 {
 public:
     AutoBalanceStatModifiers() {}
-    AutoBalanceStatModifiers (float global, float health, float mana, float armor, float damage, float boss_global) :
+    AutoBalanceStatModifiers(float global, float health, float mana, float armor, float damage, float boss_global) :
         global(global), health(health), mana(mana), armor(armor), damage(damage), boss_global(boss_global) {}
     float global;
     float health;
@@ -265,6 +265,7 @@ void LoadStatModifierOverrides(std::string dungeonIdString) // Used for reading 
         std::string val1, val2, val3, val4, val5, val6, val7;
         std::stringstream dungeonStream(delimitedValue);
         dungeonStream >> val1 >> val2 >> val3 >> val4 >> val5 >> val6 >> val7;
+
         auto dungeonMapId = atoi(val1.c_str());
         AutoBalanceStatModifiers statModifiers = AutoBalanceStatModifiers(
             atof(val2.c_str()),
@@ -1125,128 +1126,128 @@ public:
         float statMod_damage =      1.0f;
         float statMod_boss_global = 1.0f;
 
-        if (hasStatModifierOverride(mapId))
+        // Apply the per-instance-type modifiers first
+        if (instanceMap->IsHeroic())
         {
-            AutoBalanceStatModifiers* myStatModifierOverrides = &statModifierOverrides[mapId];
-
-            statMod_global = myStatModifierOverrides->global;
-            statMod_health = myStatModifierOverrides->health;
-            statMod_mana = myStatModifierOverrides->mana;
-            statMod_armor = myStatModifierOverrides->armor;
-            statMod_damage = myStatModifierOverrides->damage;
-            statMod_boss_global = myStatModifierOverrides->boss_global;
-        }
-        else
-        {
-            if (instanceMap->IsHeroic())
+            if (instanceMap->IsRaid())
             {
-                if (instanceMap->IsRaid())
+                switch (instanceMap->GetMaxPlayers())
                 {
-                    switch (instanceMap->GetMaxPlayers())
-                    {
-                        case 10:
-                            statMod_global = StatModifierRaid10MHeroic_Global;
-                            statMod_health = StatModifierRaid10MHeroic_Health;
-                            statMod_mana = StatModifierRaid10MHeroic_Mana;
-                            statMod_armor = StatModifierRaid10MHeroic_Armor;
-                            statMod_damage = StatModifierRaid10MHeroic_Damage;
-                            statMod_boss_global = StatModifierRaid10MHeroic_Boss_Global;
+                    case 10:
+                        statMod_global = StatModifierRaid10MHeroic_Global;
+                        statMod_health = StatModifierRaid10MHeroic_Health;
+                        statMod_mana = StatModifierRaid10MHeroic_Mana;
+                        statMod_armor = StatModifierRaid10MHeroic_Armor;
+                        statMod_damage = StatModifierRaid10MHeroic_Damage;
+                        statMod_boss_global = StatModifierRaid10MHeroic_Boss_Global;
 
-                            break;
-                        case 25:
-                            statMod_global = StatModifierRaid25MHeroic_Global;
-                            statMod_health = StatModifierRaid25MHeroic_Health;
-                            statMod_mana = StatModifierRaid25MHeroic_Mana;
-                            statMod_armor = StatModifierRaid25MHeroic_Armor;
-                            statMod_damage = StatModifierRaid25MHeroic_Damage;
-                            statMod_boss_global = StatModifierRaid25MHeroic_Boss_Global;
+                        break;
+                    case 25:
+                        statMod_global = StatModifierRaid25MHeroic_Global;
+                        statMod_health = StatModifierRaid25MHeroic_Health;
+                        statMod_mana = StatModifierRaid25MHeroic_Mana;
+                        statMod_armor = StatModifierRaid25MHeroic_Armor;
+                        statMod_damage = StatModifierRaid25MHeroic_Damage;
+                        statMod_boss_global = StatModifierRaid25MHeroic_Boss_Global;
 
-                            break;
-                        default:
-                            statMod_global = StatModifierRaidHeroic_Global;
-                            statMod_health = StatModifierRaidHeroic_Health;
-                            statMod_mana = StatModifierRaidHeroic_Mana;
-                            statMod_armor = StatModifierRaidHeroic_Armor;
-                            statMod_damage = StatModifierRaidHeroic_Damage;
-                            statMod_boss_global = StatModifierRaidHeroic_Boss_Global;
-                    }
-                }
-                else
-                {
-                    statMod_global = StatModifierHeroic_Global;
-                    statMod_health = StatModifierHeroic_Health;
-                    statMod_mana = StatModifierHeroic_Mana;
-                    statMod_armor = StatModifierHeroic_Armor;
-                    statMod_damage = StatModifierHeroic_Damage;
-                    statMod_boss_global = StatModifierHeroic_Boss_Global;
+                        break;
+                    default:
+                        statMod_global = StatModifierRaidHeroic_Global;
+                        statMod_health = StatModifierRaidHeroic_Health;
+                        statMod_mana = StatModifierRaidHeroic_Mana;
+                        statMod_armor = StatModifierRaidHeroic_Armor;
+                        statMod_damage = StatModifierRaidHeroic_Damage;
+                        statMod_boss_global = StatModifierRaidHeroic_Boss_Global;
                 }
             }
             else
             {
-                if (instanceMap->IsRaid())
+                statMod_global = StatModifierHeroic_Global;
+                statMod_health = StatModifierHeroic_Health;
+                statMod_mana = StatModifierHeroic_Mana;
+                statMod_armor = StatModifierHeroic_Armor;
+                statMod_damage = StatModifierHeroic_Damage;
+                statMod_boss_global = StatModifierHeroic_Boss_Global;
+            }
+        }
+        else
+        {
+            if (instanceMap->IsRaid())
+            {
+                switch (instanceMap->GetMaxPlayers())
                 {
-                    switch (instanceMap->GetMaxPlayers())
-                    {
-                        case 10:
-                            statMod_global = StatModifierRaid10M_Global;
-                            statMod_health = StatModifierRaid10M_Health;
-                            statMod_mana = StatModifierRaid10M_Mana;
-                            statMod_armor = StatModifierRaid10M_Armor;
-                            statMod_damage = StatModifierRaid10M_Damage;
-                            statMod_boss_global = StatModifierRaid10M_Boss_Global;
+                    case 10:
+                        statMod_global = StatModifierRaid10M_Global;
+                        statMod_health = StatModifierRaid10M_Health;
+                        statMod_mana = StatModifierRaid10M_Mana;
+                        statMod_armor = StatModifierRaid10M_Armor;
+                        statMod_damage = StatModifierRaid10M_Damage;
+                        statMod_boss_global = StatModifierRaid10M_Boss_Global;
 
-                            break;
-                        case 15:
-                            statMod_global = StatModifierRaid15M_Global;
-                            statMod_health = StatModifierRaid15M_Health;
-                            statMod_mana = StatModifierRaid15M_Mana;
-                            statMod_armor = StatModifierRaid15M_Armor;
-                            statMod_damage = StatModifierRaid15M_Damage;
-                            statMod_boss_global = StatModifierRaid15M_Boss_Global;
-                            break;
-                        case 20:
-                            statMod_global = StatModifierRaid20M_Global;
-                            statMod_health = StatModifierRaid20M_Health;
-                            statMod_mana = StatModifierRaid20M_Mana;
-                            statMod_armor = StatModifierRaid20M_Armor;
-                            statMod_damage = StatModifierRaid20M_Damage;
-                            statMod_boss_global = StatModifierRaid20M_Boss_Global;
-                            break;
-                        case 25:
-                            statMod_global = StatModifierRaid25M_Global;
-                            statMod_health = StatModifierRaid25M_Health;
-                            statMod_mana = StatModifierRaid25M_Mana;
-                            statMod_armor = StatModifierRaid25M_Armor;
-                            statMod_damage = StatModifierRaid25M_Damage;
-                            statMod_boss_global = StatModifierRaid25M_Boss_Global;
-                            break;
-                        case 40:
-                            statMod_global = StatModifierRaid40M_Global;
-                            statMod_health = StatModifierRaid40M_Health;
-                            statMod_mana = StatModifierRaid40M_Mana;
-                            statMod_armor = StatModifierRaid40M_Armor;
-                            statMod_damage = StatModifierRaid40M_Damage;
-                            statMod_boss_global = StatModifierRaid40M_Boss_Global;
-                            break;
-                        default:
-                            statMod_global = StatModifierRaid_Global;
-                            statMod_health = StatModifierRaid_Health;
-                            statMod_mana = StatModifierRaid_Mana;
-                            statMod_armor = StatModifierRaid_Armor;
-                            statMod_damage = StatModifierRaid_Damage;
-                            statMod_boss_global = StatModifierRaid_Boss_Global;
-                    }
-                }
-                else
-                {
-                    statMod_global = StatModifier_Global;
-                    statMod_health = StatModifier_Health;
-                    statMod_mana = StatModifier_Mana;
-                    statMod_armor = StatModifier_Armor;
-                    statMod_damage = StatModifier_Damage;
-                    statMod_boss_global = StatModifier_Boss_Global;
+                        break;
+                    case 15:
+                        statMod_global = StatModifierRaid15M_Global;
+                        statMod_health = StatModifierRaid15M_Health;
+                        statMod_mana = StatModifierRaid15M_Mana;
+                        statMod_armor = StatModifierRaid15M_Armor;
+                        statMod_damage = StatModifierRaid15M_Damage;
+                        statMod_boss_global = StatModifierRaid15M_Boss_Global;
+                        break;
+                    case 20:
+                        statMod_global = StatModifierRaid20M_Global;
+                        statMod_health = StatModifierRaid20M_Health;
+                        statMod_mana = StatModifierRaid20M_Mana;
+                        statMod_armor = StatModifierRaid20M_Armor;
+                        statMod_damage = StatModifierRaid20M_Damage;
+                        statMod_boss_global = StatModifierRaid20M_Boss_Global;
+                        break;
+                    case 25:
+                        statMod_global = StatModifierRaid25M_Global;
+                        statMod_health = StatModifierRaid25M_Health;
+                        statMod_mana = StatModifierRaid25M_Mana;
+                        statMod_armor = StatModifierRaid25M_Armor;
+                        statMod_damage = StatModifierRaid25M_Damage;
+                        statMod_boss_global = StatModifierRaid25M_Boss_Global;
+                        break;
+                    case 40:
+                        statMod_global = StatModifierRaid40M_Global;
+                        statMod_health = StatModifierRaid40M_Health;
+                        statMod_mana = StatModifierRaid40M_Mana;
+                        statMod_armor = StatModifierRaid40M_Armor;
+                        statMod_damage = StatModifierRaid40M_Damage;
+                        statMod_boss_global = StatModifierRaid40M_Boss_Global;
+                        break;
+                    default:
+                        statMod_global = StatModifierRaid_Global;
+                        statMod_health = StatModifierRaid_Health;
+                        statMod_mana = StatModifierRaid_Mana;
+                        statMod_armor = StatModifierRaid_Armor;
+                        statMod_damage = StatModifierRaid_Damage;
+                        statMod_boss_global = StatModifierRaid_Boss_Global;
                 }
             }
+            else
+            {
+                statMod_global = StatModifier_Global;
+                statMod_health = StatModifier_Health;
+                statMod_mana = StatModifier_Mana;
+                statMod_armor = StatModifier_Armor;
+                statMod_damage = StatModifier_Damage;
+                statMod_boss_global = StatModifier_Boss_Global;
+            }
+        }
+
+        // Per map ID overrides replace the above settings, if set
+        if (hasStatModifierOverride(mapId))
+        {
+            AutoBalanceStatModifiers* myStatModifierOverrides = &statModifierOverrides[mapId];
+
+            if (myStatModifierOverrides->global > 0)      {statMod_global =      myStatModifierOverrides->global;     }
+            if (myStatModifierOverrides->health > 0)      {statMod_health =      myStatModifierOverrides->health;     }
+            if (myStatModifierOverrides->mana > 0)        {statMod_mana =        myStatModifierOverrides->mana;       }
+            if (myStatModifierOverrides->armor > 0)       {statMod_armor =       myStatModifierOverrides->armor;      }
+            if (myStatModifierOverrides->damage > 0)      {statMod_damage =      myStatModifierOverrides->damage;     }
+            if (myStatModifierOverrides->boss_global > 0) {statMod_boss_global = myStatModifierOverrides->boss_global;}
         }
 
         if (creatureABInfo->instancePlayerCount >= maxNumberOfPlayers)

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -838,13 +838,13 @@ public:
                             inflectionValue *= InflectionPointRaid25MHeroic;
                             curveFloor = InflectionPointRaid25MHeroicCurveFloor;
                             curveCeiling = InflectionPointRaid25MHeroicCurveCeiling;
-                            bossMultiplier = InflectionPointRaid25MHeroic;
+                            bossMultiplier = InflectionPointRaid25MHeroicBoss;
                             break;
                         default:
                             inflectionValue *= InflectionPointRaidHeroic;
                             curveFloor = InflectionPointRaidHeroicCurveFloor;
                             curveCeiling = InflectionPointRaidHeroicCurveCeiling;
-                            bossMultiplier = InflectionPointRaidHeroic;
+                            bossMultiplier = InflectionPointRaidHeroicBoss;
                     }
                 }
                 else
@@ -877,7 +877,7 @@ public:
                             inflectionValue *= InflectionPointRaid20M;
                             curveFloor = InflectionPointRaid20MCurveFloor;
                             curveCeiling = InflectionPointRaid20MCurveCeiling;
-                            bossMultiplier = InflectionPointRaid20M;
+                            bossMultiplier = InflectionPointRaid20MBoss;
                             break;
                         case 25:
                             inflectionValue *= InflectionPointRaid25M;
@@ -889,13 +889,13 @@ public:
                             inflectionValue *= InflectionPointRaid40M;
                             curveFloor = InflectionPointRaid40MCurveFloor;
                             curveCeiling = InflectionPointRaid40MCurveCeiling;
-                            bossMultiplier = InflectionPointRaid40M;
+                            bossMultiplier = InflectionPointRaid40MBoss;
                             break;
                         default:
                             inflectionValue *= InflectionPointRaid;
                             curveFloor = InflectionPointRaidCurveFloor;
                             curveCeiling = InflectionPointRaidCurveCeiling;
-                            bossMultiplier = InflectionPointRaid;
+                            bossMultiplier = InflectionPointRaidBoss;
                     }
                 }
                 else

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -1321,21 +1321,18 @@ public:
             if (myStatModifierOverrides->boss_global != -1) { statMod_boss_global = myStatModifierOverrides->boss_global; }
         }
 
+        // Calculate our starting multiplier before adjustments
+        float diff = ((float)maxNumberOfPlayers/5)*1.5f;
+        defaultMultiplier = (tanh(((float)creatureABInfo->instancePlayerCount - inflectionValue) / diff) + 1.0f) / 2.0f;
 
-        if (creatureABInfo->instancePlayerCount >= maxNumberOfPlayers)
-        // We've maxed out the number of players, engage maximum difficulty!
-        {
-            defaultMultiplier = curveCeiling;
-        }
-        else
-        // Less than full instance, adjust accordingly
-        {
-            float diff = ((float)maxNumberOfPlayers/5)*1.5f;
-            defaultMultiplier = (tanh(((float)creatureABInfo->instancePlayerCount - inflectionValue) / diff) + 1.0f) / 2.0f;
+        // For math reasons that I do not understand, curveCeiling needs to be adjusted to bring the actual multiplier
+        // closer to the curveCeiling setting. Create an adjustment based on how much the ceiling should be changed at
+        // the max players multiplier.
+        float curveCeilingAdjustment = curveCeiling / ((tanh(((float)maxNumberOfPlayers - inflectionValue) / diff) + 1.0f) / 2.0f);
 
-            // Adjust the multiplier based on the configured floor and ceiling values
-            defaultMultiplier = (defaultMultiplier * (curveCeiling - curveFloor) + curveFloor);
-        }
+        // Adjust the multiplier based on the configured floor and ceiling values
+        defaultMultiplier = (defaultMultiplier * (curveCeiling * curveCeilingAdjustment - curveFloor) + curveFloor);
+
 
         if (!sABScriptMgr->OnAfterDefaultMultiplier(creature, defaultMultiplier))
             return;

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -138,14 +138,13 @@ class AutoBalanceStatModifiers : public DataMap::Base
 {
 public:
     AutoBalanceStatModifiers() {}
-    AutoBalanceStatModifiers(float global, float health, float mana, float armor, float damage, float boss_global) :
-        global(global), health(health), mana(mana), armor(armor), damage(damage), boss_global(boss_global) {}
+    AutoBalanceStatModifiers(float global, float health, float mana, float armor, float damage) :
+        global(global), health(health), mana(mana), armor(armor), damage(damage) {}
     float global;
     float health;
     float mana;
     float armor;
     float damage;
-    float boss_global;
 };
 
 class AutoBalanceInflectionPointSettings : public DataMap::Base
@@ -165,6 +164,8 @@ static std::map<uint32, uint8> enabledDungeonIds;
 static std::map<uint32, AutoBalanceInflectionPointSettings> dungeonOverrides;
 static std::map<uint32, AutoBalanceInflectionPointSettings> bossOverrides;
 static std::map<uint32, AutoBalanceStatModifiers> statModifierOverrides;
+static std::map<uint32, AutoBalanceStatModifiers> statModifierBossOverrides;
+static std::map<uint32, AutoBalanceStatModifiers> statModifierCreatureOverrides;
 // cheaphack for difficulty server-wide.
 // Another value TODO in player class for the party leader's value to determine dungeon difficulty.
 static int8 PlayerCountDifficultyOffset, LevelScaling, higherOffset, lowerOffset;
@@ -187,19 +188,32 @@ static float InflectionPointRaid25MHeroic, InflectionPointRaid25MHeroicCurveFloo
 static float InflectionPointRaid40M, InflectionPointRaid40MCurveFloor, InflectionPointRaid40MCurveCeiling, InflectionPointRaid40MBoss;
 
 // StatModifier*
-static float StatModifier_Global, StatModifier_Health, StatModifier_Mana, StatModifier_Armor, StatModifier_Damage, StatModifier_Boss_Global;
-static float StatModifierHeroic_Global, StatModifierHeroic_Health, StatModifierHeroic_Mana, StatModifierHeroic_Armor, StatModifierHeroic_Damage, StatModifierHeroic_Boss_Global;
-static float StatModifierRaid_Global, StatModifierRaid_Health, StatModifierRaid_Mana, StatModifierRaid_Armor, StatModifierRaid_Damage, StatModifierRaid_Boss_Global;
-static float StatModifierRaidHeroic_Global, StatModifierRaidHeroic_Health, StatModifierRaidHeroic_Mana, StatModifierRaidHeroic_Armor, StatModifierRaidHeroic_Damage, StatModifierRaidHeroic_Boss_Global;
+static float StatModifier_Global, StatModifier_Health, StatModifier_Mana, StatModifier_Armor, StatModifier_Damage;
+static float StatModifierHeroic_Global, StatModifierHeroic_Health, StatModifierHeroic_Mana, StatModifierHeroic_Armor, StatModifierHeroic_Damage;
+static float StatModifierRaid_Global, StatModifierRaid_Health, StatModifierRaid_Mana, StatModifierRaid_Armor, StatModifierRaid_Damage;
+static float StatModifierRaidHeroic_Global, StatModifierRaidHeroic_Health, StatModifierRaidHeroic_Mana, StatModifierRaidHeroic_Armor, StatModifierRaidHeroic_Damage;
 
-static float StatModifierRaid10M_Global, StatModifierRaid10M_Health, StatModifierRaid10M_Mana, StatModifierRaid10M_Armor, StatModifierRaid10M_Damage, StatModifierRaid10M_Boss_Global;
-static float StatModifierRaid10MHeroic_Global, StatModifierRaid10MHeroic_Health, StatModifierRaid10MHeroic_Mana, StatModifierRaid10MHeroic_Armor, StatModifierRaid10MHeroic_Damage, StatModifierRaid10MHeroic_Boss_Global;
-static float StatModifierRaid15M_Global, StatModifierRaid15M_Health, StatModifierRaid15M_Mana, StatModifierRaid15M_Armor, StatModifierRaid15M_Damage, StatModifierRaid15M_Boss_Global;
-static float StatModifierRaid20M_Global, StatModifierRaid20M_Health, StatModifierRaid20M_Mana, StatModifierRaid20M_Armor, StatModifierRaid20M_Damage, StatModifierRaid20M_Boss_Global;
-static float StatModifierRaid25M_Global, StatModifierRaid25M_Health, StatModifierRaid25M_Mana, StatModifierRaid25M_Armor, StatModifierRaid25M_Damage, StatModifierRaid25M_Boss_Global;
-static float StatModifierRaid25MHeroic_Global, StatModifierRaid25MHeroic_Health, StatModifierRaid25MHeroic_Mana, StatModifierRaid25MHeroic_Armor, StatModifierRaid25MHeroic_Damage, StatModifierRaid25MHeroic_Boss_Global;
-static float StatModifierRaid40M_Global, StatModifierRaid40M_Health, StatModifierRaid40M_Mana, StatModifierRaid40M_Armor, StatModifierRaid40M_Damage, StatModifierRaid40M_Boss_Global;
+static float StatModifierRaid10M_Global, StatModifierRaid10M_Health, StatModifierRaid10M_Mana, StatModifierRaid10M_Armor, StatModifierRaid10M_Damage;
+static float StatModifierRaid10MHeroic_Global, StatModifierRaid10MHeroic_Health, StatModifierRaid10MHeroic_Mana, StatModifierRaid10MHeroic_Armor, StatModifierRaid10MHeroic_Damage;
+static float StatModifierRaid15M_Global, StatModifierRaid15M_Health, StatModifierRaid15M_Mana, StatModifierRaid15M_Armor, StatModifierRaid15M_Damage;
+static float StatModifierRaid20M_Global, StatModifierRaid20M_Health, StatModifierRaid20M_Mana, StatModifierRaid20M_Armor, StatModifierRaid20M_Damage;
+static float StatModifierRaid25M_Global, StatModifierRaid25M_Health, StatModifierRaid25M_Mana, StatModifierRaid25M_Armor, StatModifierRaid25M_Damage;
+static float StatModifierRaid25MHeroic_Global, StatModifierRaid25MHeroic_Health, StatModifierRaid25MHeroic_Mana, StatModifierRaid25MHeroic_Armor, StatModifierRaid25MHeroic_Damage;
+static float StatModifierRaid40M_Global, StatModifierRaid40M_Health, StatModifierRaid40M_Mana, StatModifierRaid40M_Armor, StatModifierRaid40M_Damage;
 
+// StatModifier* (Boss)
+static float StatModifier_Boss_Global, StatModifier_Boss_Health, StatModifier_Boss_Mana, StatModifier_Boss_Armor, StatModifier_Boss_Damage;
+static float StatModifierHeroic_Boss_Global, StatModifierHeroic_Boss_Health, StatModifierHeroic_Boss_Mana, StatModifierHeroic_Boss_Armor, StatModifierHeroic_Boss_Damage;
+static float StatModifierRaid_Boss_Global, StatModifierRaid_Boss_Health, StatModifierRaid_Boss_Mana, StatModifierRaid_Boss_Armor, StatModifierRaid_Boss_Damage;
+static float StatModifierRaidHeroic_Boss_Global, StatModifierRaidHeroic_Boss_Health, StatModifierRaidHeroic_Boss_Mana, StatModifierRaidHeroic_Boss_Armor, StatModifierRaidHeroic_Boss_Damage;
+
+static float StatModifierRaid10M_Boss_Global, StatModifierRaid10M_Boss_Health, StatModifierRaid10M_Boss_Mana, StatModifierRaid10M_Boss_Armor, StatModifierRaid10M_Boss_Damage;
+static float StatModifierRaid10MHeroic_Boss_Global, StatModifierRaid10MHeroic_Boss_Health, StatModifierRaid10MHeroic_Boss_Mana, StatModifierRaid10MHeroic_Boss_Armor, StatModifierRaid10MHeroic_Boss_Damage;
+static float StatModifierRaid15M_Boss_Global, StatModifierRaid15M_Boss_Health, StatModifierRaid15M_Boss_Mana, StatModifierRaid15M_Boss_Armor, StatModifierRaid15M_Boss_Damage;
+static float StatModifierRaid20M_Boss_Global, StatModifierRaid20M_Boss_Health, StatModifierRaid20M_Boss_Mana, StatModifierRaid20M_Boss_Armor, StatModifierRaid20M_Boss_Damage;
+static float StatModifierRaid25M_Boss_Global, StatModifierRaid25M_Boss_Health, StatModifierRaid25M_Boss_Mana, StatModifierRaid25M_Boss_Armor, StatModifierRaid25M_Boss_Damage;
+static float StatModifierRaid25MHeroic_Boss_Global, StatModifierRaid25MHeroic_Boss_Health, StatModifierRaid25MHeroic_Boss_Mana, StatModifierRaid25MHeroic_Boss_Armor, StatModifierRaid25MHeroic_Boss_Damage;
+static float StatModifierRaid40M_Boss_Global, StatModifierRaid40M_Boss_Health, StatModifierRaid40M_Boss_Mana, StatModifierRaid40M_Boss_Armor, StatModifierRaid40M_Boss_Damage;
 
 int GetValidDebugLevel()
 {
@@ -282,19 +296,16 @@ std::map<uint32, AutoBalanceStatModifiers> LoadStatModifierOverrides(std::string
         if (val4.empty()) { val4 = "-1"; }
         if (val5.empty()) { val5 = "-1"; }
         if (val6.empty()) { val6 = "-1"; }
-        if (val7.empty()) { val7 = "-1"; }
 
         AutoBalanceStatModifiers statSettings = AutoBalanceStatModifiers(
             atof(val2.c_str()),
             atof(val3.c_str()),
             atof(val4.c_str()),
             atof(val5.c_str()),
-            atof(val6.c_str()),
-            atof(val7.c_str())
+            atof(val6.c_str())
         );
 
         overrideMap[dungeonMapId] = statSettings;
-        LOG_ERROR("AutoBalance", "StatModifier overrides for map `{}` are {} {} {} {} {} {}", val1, val2, val3, val4, val5, val6, val7);
     }
 
     return overrideMap;
@@ -324,6 +335,16 @@ bool hasBossOverride(uint32 dungeonId)
 bool hasStatModifierOverride(uint32 dungeonId)
 {
     return (statModifierOverrides.find(dungeonId) != statModifierOverrides.end());
+}
+
+bool hasStatModifierBossOverride(uint32 dungeonId)
+{
+    return (statModifierBossOverrides.find(dungeonId) != statModifierBossOverrides.end());
+}
+
+bool hasStatModifierCreatureOverride(uint32 creatureId)
+{
+    return (statModifierCreatureOverrides.find(creatureId) != statModifierCreatureOverrides.end());
 }
 
 void LoadForcedCreatureIdsFromString(std::string creatureIds, int forcedPlayerCount) // Used for reading the string from the configuration file to for those creatures who need to be scaled for XX number of players.
@@ -392,6 +413,8 @@ class AutoBalance_WorldScript : public WorldScript
         dungeonOverrides.clear();
         bossOverrides.clear();
         statModifierOverrides.clear();
+        statModifierBossOverrides.clear();
+        statModifierCreatureOverrides.clear();
         LoadForcedCreatureIdsFromString(sConfigMgr->GetOption<std::string>("AutoBalance.ForcedID40", ""), 40);
         LoadForcedCreatureIdsFromString(sConfigMgr->GetOption<std::string>("AutoBalance.ForcedID25", ""), 25);
         LoadForcedCreatureIdsFromString(sConfigMgr->GetOption<std::string>("AutoBalance.ForcedID10", ""), 10);
@@ -415,6 +438,14 @@ class AutoBalance_WorldScript : public WorldScript
 
         statModifierOverrides = LoadStatModifierOverrides(
             sConfigMgr->GetOption<std::string>("AutoBalance.StatModifier.PerInstance", "", false)
+        );
+
+        statModifierBossOverrides = LoadStatModifierOverrides(
+            sConfigMgr->GetOption<std::string>("AutoBalance.StatModifier.Boss.PerInstance", "", false)
+        );
+
+        statModifierCreatureOverrides = LoadStatModifierOverrides(
+            sConfigMgr->GetOption<std::string>("AutoBalance.StatModifier.PerCreature", "", false)
         );
 
         enabled = sConfigMgr->GetOption<bool>("AutoBalance.enable", 1);
@@ -507,82 +538,148 @@ class AutoBalance_WorldScript : public WorldScript
         if (sConfigMgr->GetOption<float>("AutoBalance.rate.damage", false, false))
             LOG_WARN("server.loading", "mod-autobalance: deprecated value `AutoBalance.rate.damage` defined in `AutoBalance.conf`. This variable will be removed in a future release. Please see `AutoBalance.conf.dist` for more details.");
 
+        // 5-player dungeons
         StatModifier_Global =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
         StatModifier_Health =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
         StatModifier_Mana =                         sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
         StatModifier_Armor =                        sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
         StatModifier_Damage =                       sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
-        StatModifier_Boss_Global =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Global", 1.0f);
 
+        StatModifier_Boss_Global =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifier_Boss_Health =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifier_Boss_Mana =                    sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifier_Boss_Armor =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifier_Boss_Damage =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifier.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+
+        // 5-player heroic dungeons
         StatModifierHeroic_Global =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
         StatModifierHeroic_Health =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
         StatModifierHeroic_Mana =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
         StatModifierHeroic_Armor =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
         StatModifierHeroic_Damage =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
-        StatModifierHeroic_Boss_Global =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Global", 1.0f);
 
+        StatModifierHeroic_Boss_Global =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifierHeroic_Boss_Health =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifierHeroic_Boss_Mana =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifierHeroic_Boss_Armor =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifierHeroic_Boss_Damage =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierHeroic.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+
+        // Default for all raids
         StatModifierRaid_Global =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
         StatModifierRaid_Health =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
         StatModifierRaid_Mana =                     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
         StatModifierRaid_Armor =                    sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
         StatModifierRaid_Damage =                   sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
-        StatModifierRaid_Boss_Global =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Global", 1.0f);
 
+        StatModifierRaid_Boss_Global =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifierRaid_Boss_Health =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifierRaid_Boss_Mana =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifierRaid_Boss_Armor =               sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifierRaid_Boss_Damage =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
+
+        // Default for all heroic raids
         StatModifierRaidHeroic_Global =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
         StatModifierRaidHeroic_Health =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
         StatModifierRaidHeroic_Mana =               sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
         StatModifierRaidHeroic_Armor =              sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
         StatModifierRaidHeroic_Damage =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
-        StatModifierRaidHeroic_Boss_Global =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Global", 1.0f);
 
-        StatModifierRaid10M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Global", 1.0f, false);
-        StatModifierRaid10M_Health =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Health", 1.0f, false);
-        StatModifierRaid10M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Mana", 1.0f, false);
-        StatModifierRaid10M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Armor", 1.0f, false);
-        StatModifierRaid10M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Damage", 1.0f, false);
-        StatModifierRaid10M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Global", 1.0f, false);
+        StatModifierRaidHeroic_Boss_Global =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Global", sConfigMgr->GetOption<float>("AutoBalance.rate.global", 1.0f, false)); // `AutoBalance.rate.global` for backwards compatibility
+        StatModifierRaidHeroic_Boss_Health =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Health", sConfigMgr->GetOption<float>("AutoBalance.rate.health", 1.0f, false)); // `AutoBalance.rate.health` for backwards compatibility
+        StatModifierRaidHeroic_Boss_Mana =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Mana", sConfigMgr->GetOption<float>("AutoBalance.rate.mana", 1.0f, false)); // `AutoBalance.rate.mana` for backwards compatibility
+        StatModifierRaidHeroic_Boss_Armor =         sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Armor", sConfigMgr->GetOption<float>("AutoBalance.rate.armor", 1.0f, false)); // `AutoBalance.rate.armor` for backwards compatibility
+        StatModifierRaidHeroic_Boss_Damage =        sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaidHeroic.Boss.Damage", sConfigMgr->GetOption<float>("AutoBalance.rate.damage", 1.0f, false)); // `AutoBalance.rate.damage` for backwards compatibility
 
-        StatModifierRaid10MHeroic_Global =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Global", 1.0f, false);
-        StatModifierRaid10MHeroic_Health =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Health", 1.0f, false);
-        StatModifierRaid10MHeroic_Mana =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Mana", 1.0f, false);
-        StatModifierRaid10MHeroic_Armor =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Armor", 1.0f, false);
-        StatModifierRaid10MHeroic_Damage =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Damage", 1.0f, false);
-        StatModifierRaid10MHeroic_Boss_Global =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Global", 1.0f, false);
+        // 10-player raids
+        StatModifierRaid10M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Global", StatModifierRaid_Global, false);
+        StatModifierRaid10M_Health =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Health", StatModifierRaid_Health, false);
+        StatModifierRaid10M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Mana", StatModifierRaid_Mana, false);
+        StatModifierRaid10M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Armor", StatModifierRaid_Armor, false);
+        StatModifierRaid10M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Damage", StatModifierRaid_Damage, false);
 
-        StatModifierRaid15M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Global", 1.0f, false);
-        StatModifierRaid15M_Health =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Health", 1.0f, false);
-        StatModifierRaid15M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Mana", 1.0f, false);
-        StatModifierRaid15M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Armor", 1.0f, false);
-        StatModifierRaid15M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Damage", 1.0f, false);
-        StatModifierRaid15M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Global", 1.0f, false);
+        StatModifierRaid10M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Global", StatModifierRaid_Boss_Global, false);
+        StatModifierRaid10M_Boss_Health =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Health", StatModifierRaid_Boss_Health, false);
+        StatModifierRaid10M_Boss_Mana =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Mana", StatModifierRaid_Boss_Mana, false);
+        StatModifierRaid10M_Boss_Armor =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Armor", StatModifierRaid_Boss_Armor, false);
+        StatModifierRaid10M_Boss_Damage =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10M.Boss.Damage", StatModifierRaid_Boss_Damage, false);
 
-        StatModifierRaid20M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Global", 1.0f, false);
-        StatModifierRaid20M_Health =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Health", 1.0f, false);
-        StatModifierRaid20M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Mana", 1.0f, false);
-        StatModifierRaid20M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Armor", 1.0f, false);
-        StatModifierRaid20M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Damage", 1.0f, false);
-        StatModifierRaid20M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Global", 1.0f, false);
+        // 10-player heroic raids
+        StatModifierRaid10MHeroic_Global =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Global", StatModifierRaidHeroic_Global, false);
+        StatModifierRaid10MHeroic_Health =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Health", StatModifierRaidHeroic_Health, false);
+        StatModifierRaid10MHeroic_Mana =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Mana", StatModifierRaidHeroic_Mana, false);
+        StatModifierRaid10MHeroic_Armor =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Armor", StatModifierRaidHeroic_Armor, false);
+        StatModifierRaid10MHeroic_Damage =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Damage", StatModifierRaidHeroic_Damage, false);
 
-        StatModifierRaid25M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Global", 1.0f, false);
-        StatModifierRaid25M_Health =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Health", 1.0f, false);
-        StatModifierRaid25M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Mana", 1.0f, false);
-        StatModifierRaid25M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Armor", 1.0f, false);
-        StatModifierRaid25M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Damage", 1.0f, false);
-        StatModifierRaid25M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Global", 1.0f, false);
+        StatModifierRaid10MHeroic_Boss_Global =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Global", StatModifierRaidHeroic_Boss_Global, false);
+        StatModifierRaid10MHeroic_Boss_Health =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Health", StatModifierRaidHeroic_Boss_Health, false);
+        StatModifierRaid10MHeroic_Boss_Mana =       sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Mana", StatModifierRaidHeroic_Boss_Mana, false);
+        StatModifierRaid10MHeroic_Boss_Armor =      sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Armor", StatModifierRaidHeroic_Boss_Armor, false);
+        StatModifierRaid10MHeroic_Boss_Damage =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid10MHeroic.Boss.Damage", StatModifierRaidHeroic_Boss_Damage, false);
 
-        StatModifierRaid25MHeroic_Global =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Global", 1.0f, false);
-        StatModifierRaid25MHeroic_Health =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Health", 1.0f, false);
-        StatModifierRaid25MHeroic_Mana =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Mana", 1.0f, false);
-        StatModifierRaid25MHeroic_Armor =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Armor", 1.0f, false);
-        StatModifierRaid25MHeroic_Damage =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Damage", 1.0f, false);
-        StatModifierRaid25MHeroic_Boss_Global =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Global", 1.0f, false);
+        // 15-player raids
+        StatModifierRaid15M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Global", StatModifierRaid_Global, false);
+        StatModifierRaid15M_Health =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Health", StatModifierRaid_Health, false);
+        StatModifierRaid15M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Mana", StatModifierRaid_Mana, false);
+        StatModifierRaid15M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Armor", StatModifierRaid_Armor, false);
+        StatModifierRaid15M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Damage", StatModifierRaid_Damage, false);
 
-        StatModifierRaid40M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Global", 1.0f, false);
-        StatModifierRaid40M_Health =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Health", 1.0f, false);
-        StatModifierRaid40M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Mana", 1.0f, false);
-        StatModifierRaid40M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Armor", 1.0f, false);
-        StatModifierRaid40M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Damage", 1.0f, false);
-        StatModifierRaid40M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Global", 1.0f, false);
+        StatModifierRaid15M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Global", StatModifierRaid_Boss_Global, false);
+        StatModifierRaid15M_Boss_Health =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Health", StatModifierRaid_Boss_Health, false);
+        StatModifierRaid15M_Boss_Mana =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Mana", StatModifierRaid_Boss_Mana, false);
+        StatModifierRaid15M_Boss_Armor =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Armor", StatModifierRaid_Boss_Armor, false);
+        StatModifierRaid15M_Boss_Damage =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid15M.Boss.Damage", StatModifierRaid_Boss_Damage, false);
+
+        // 20-player raids
+        StatModifierRaid20M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Global", StatModifierRaid_Global, false);
+        StatModifierRaid20M_Health =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Health", StatModifierRaid_Health, false);
+        StatModifierRaid20M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Mana", StatModifierRaid_Mana, false);
+        StatModifierRaid20M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Armor", StatModifierRaid_Armor, false);
+        StatModifierRaid20M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Damage", StatModifierRaid_Damage, false);
+
+        StatModifierRaid20M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Global", StatModifierRaid_Boss_Global, false);
+        StatModifierRaid20M_Boss_Health =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Health", StatModifierRaid_Boss_Health, false);
+        StatModifierRaid20M_Boss_Mana =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Mana", StatModifierRaid_Boss_Mana, false);
+        StatModifierRaid20M_Boss_Armor =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Armor", StatModifierRaid_Boss_Armor, false);
+        StatModifierRaid20M_Boss_Damage =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid20M.Boss.Damage", StatModifierRaid_Boss_Damage, false);
+
+        // 25-player raids
+        StatModifierRaid25M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Global", StatModifierRaid_Global, false);
+        StatModifierRaid25M_Health =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Health", StatModifierRaid_Health, false);
+        StatModifierRaid25M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Mana", StatModifierRaid_Mana, false);
+        StatModifierRaid25M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Armor", StatModifierRaid_Armor, false);
+        StatModifierRaid25M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Damage", StatModifierRaid_Damage, false);
+
+        StatModifierRaid25M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Global", StatModifierRaid_Boss_Global, false);
+        StatModifierRaid25M_Boss_Health =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Health", StatModifierRaid_Boss_Health, false);
+        StatModifierRaid25M_Boss_Mana =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Mana", StatModifierRaid_Boss_Mana, false);
+        StatModifierRaid25M_Boss_Armor =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Armor", StatModifierRaid_Boss_Armor, false);
+        StatModifierRaid25M_Boss_Damage =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25M.Boss.Damage", StatModifierRaid_Boss_Damage, false);
+
+        // 25-player heroic raids
+        StatModifierRaid25MHeroic_Global =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Global", StatModifierRaidHeroic_Global, false);
+        StatModifierRaid25MHeroic_Health =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Health", StatModifierRaidHeroic_Health, false);
+        StatModifierRaid25MHeroic_Mana =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Mana", StatModifierRaidHeroic_Mana, false);
+        StatModifierRaid25MHeroic_Armor =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Armor", StatModifierRaidHeroic_Armor, false);
+        StatModifierRaid25MHeroic_Damage =          sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Damage", StatModifierRaidHeroic_Damage, false);
+
+        StatModifierRaid25MHeroic_Boss_Global =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Global", StatModifierRaidHeroic_Boss_Global, false);
+        StatModifierRaid25MHeroic_Boss_Health =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Health", StatModifierRaidHeroic_Boss_Health, false);
+        StatModifierRaid25MHeroic_Boss_Mana =       sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Mana", StatModifierRaidHeroic_Boss_Mana, false);
+        StatModifierRaid25MHeroic_Boss_Armor =      sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Armor", StatModifierRaidHeroic_Boss_Armor, false);
+        StatModifierRaid25MHeroic_Boss_Damage =     sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid25MHeroic.Boss.Damage", StatModifierRaidHeroic_Boss_Damage, false);
+
+        // 40-player raids
+        StatModifierRaid40M_Global =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Global", StatModifierRaid_Global, false);
+        StatModifierRaid40M_Health =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Health", StatModifierRaid_Health, false);
+        StatModifierRaid40M_Mana =                  sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Mana", StatModifierRaid_Mana, false);
+        StatModifierRaid40M_Armor =                 sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Armor", StatModifierRaid_Armor, false);
+        StatModifierRaid40M_Damage =                sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Damage", StatModifierRaid_Damage, false);
+
+        StatModifierRaid40M_Boss_Global =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Global", StatModifierRaid_Boss_Global, false);
+        StatModifierRaid40M_Boss_Health =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Health", StatModifierRaid_Boss_Health, false);
+        StatModifierRaid40M_Boss_Mana =             sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Mana", StatModifierRaid_Boss_Mana, false);
+        StatModifierRaid40M_Boss_Armor =            sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Armor", StatModifierRaid_Boss_Armor, false);
+        StatModifierRaid40M_Boss_Damage =           sConfigMgr->GetOption<float>("AutoBalance.StatModifierRaid40M.Boss.Damage", StatModifierRaid_Boss_Damage, false);
 
         // Modifier Minimums
         MinHPModifier = sConfigMgr->GetOption<float>("AutoBalance.MinHPModifier", 0.1f);
@@ -871,6 +968,15 @@ public:
 
         ModifyCreatureAttributes(creature);
     }
+
+    void OnCreatureAddWorld(Creature* creature) override
+    {
+        if (!enabled)
+            return;
+
+        ModifyCreatureAttributes(creature, true);
+    }
+
 
     bool checkLevelOffset(uint8 selectedLevel, uint8 targetLevel) {
         return selectedLevel && ((targetLevel >= selectedLevel && targetLevel <= (selectedLevel + higherOffset) ) || (targetLevel <= selectedLevel && targetLevel >= (selectedLevel - lowerOffset)));
@@ -1196,6 +1302,10 @@ public:
         float statMod_armor =       1.0f;
         float statMod_damage =      1.0f;
         float statMod_boss_global = 1.0f;
+        float statMod_boss_health = 1.0f;
+        float statMod_boss_mana =   1.0f;
+        float statMod_boss_armor =  1.0f;
+        float statMod_boss_damage = 1.0f;
 
         // Apply the per-instance-type modifiers first
         if (instanceMap->IsHeroic())
@@ -1211,7 +1321,10 @@ public:
                         statMod_armor = StatModifierRaid10MHeroic_Armor;
                         statMod_damage = StatModifierRaid10MHeroic_Damage;
                         statMod_boss_global = StatModifierRaid10MHeroic_Boss_Global;
-
+                        statMod_boss_health = StatModifierRaid10MHeroic_Boss_Health;
+                        statMod_boss_mana = StatModifierRaid10MHeroic_Boss_Mana;
+                        statMod_boss_armor = StatModifierRaid10MHeroic_Boss_Armor;
+                        statMod_boss_damage = StatModifierRaid10MHeroic_Boss_Damage;
                         break;
                     case 25:
                         statMod_global = StatModifierRaid25MHeroic_Global;
@@ -1220,7 +1333,10 @@ public:
                         statMod_armor = StatModifierRaid25MHeroic_Armor;
                         statMod_damage = StatModifierRaid25MHeroic_Damage;
                         statMod_boss_global = StatModifierRaid25MHeroic_Boss_Global;
-
+                        statMod_boss_health = StatModifierRaid25MHeroic_Boss_Health;
+                        statMod_boss_mana = StatModifierRaid25MHeroic_Boss_Mana;
+                        statMod_boss_armor = StatModifierRaid25MHeroic_Boss_Armor;
+                        statMod_boss_damage = StatModifierRaid25MHeroic_Boss_Damage;
                         break;
                     default:
                         statMod_global = StatModifierRaidHeroic_Global;
@@ -1228,7 +1344,11 @@ public:
                         statMod_mana = StatModifierRaidHeroic_Mana;
                         statMod_armor = StatModifierRaidHeroic_Armor;
                         statMod_damage = StatModifierRaidHeroic_Damage;
-                        statMod_boss_global = StatModifierRaidHeroic_Boss_Global;
+                        statMod_boss_global = StatModifierRaidHeroic_Global;
+                        statMod_boss_health = StatModifierRaidHeroic_Health;
+                        statMod_boss_mana = StatModifierRaidHeroic_Mana;
+                        statMod_boss_armor = StatModifierRaidHeroic_Armor;
+                        statMod_boss_damage = StatModifierRaidHeroic_Damage;
                 }
             }
             else
@@ -1239,6 +1359,10 @@ public:
                 statMod_armor = StatModifierHeroic_Armor;
                 statMod_damage = StatModifierHeroic_Damage;
                 statMod_boss_global = StatModifierHeroic_Boss_Global;
+                statMod_boss_health = StatModifierHeroic_Boss_Health;
+                statMod_boss_mana = StatModifierHeroic_Boss_Mana;
+                statMod_boss_armor = StatModifierHeroic_Boss_Armor;
+                statMod_boss_damage = StatModifierHeroic_Boss_Damage;
             }
         }
         else
@@ -1254,7 +1378,10 @@ public:
                         statMod_armor = StatModifierRaid10M_Armor;
                         statMod_damage = StatModifierRaid10M_Damage;
                         statMod_boss_global = StatModifierRaid10M_Boss_Global;
-
+                        statMod_boss_health = StatModifierRaid10M_Boss_Health;
+                        statMod_boss_mana = StatModifierRaid10M_Boss_Mana;
+                        statMod_boss_armor = StatModifierRaid10M_Boss_Armor;
+                        statMod_boss_damage = StatModifierRaid10M_Boss_Damage;
                         break;
                     case 15:
                         statMod_global = StatModifierRaid15M_Global;
@@ -1263,6 +1390,10 @@ public:
                         statMod_armor = StatModifierRaid15M_Armor;
                         statMod_damage = StatModifierRaid15M_Damage;
                         statMod_boss_global = StatModifierRaid15M_Boss_Global;
+                        statMod_boss_health = StatModifierRaid15M_Boss_Health;
+                        statMod_boss_mana = StatModifierRaid15M_Boss_Mana;
+                        statMod_boss_armor = StatModifierRaid15M_Boss_Armor;
+                        statMod_boss_damage = StatModifierRaid15M_Boss_Damage;
                         break;
                     case 20:
                         statMod_global = StatModifierRaid20M_Global;
@@ -1271,6 +1402,10 @@ public:
                         statMod_armor = StatModifierRaid20M_Armor;
                         statMod_damage = StatModifierRaid20M_Damage;
                         statMod_boss_global = StatModifierRaid20M_Boss_Global;
+                        statMod_boss_health = StatModifierRaid20M_Boss_Health;
+                        statMod_boss_mana = StatModifierRaid20M_Boss_Mana;
+                        statMod_boss_armor = StatModifierRaid20M_Boss_Armor;
+                        statMod_boss_damage = StatModifierRaid20M_Boss_Damage;
                         break;
                     case 25:
                         statMod_global = StatModifierRaid25M_Global;
@@ -1279,6 +1414,10 @@ public:
                         statMod_armor = StatModifierRaid25M_Armor;
                         statMod_damage = StatModifierRaid25M_Damage;
                         statMod_boss_global = StatModifierRaid25M_Boss_Global;
+                        statMod_boss_health = StatModifierRaid25M_Boss_Health;
+                        statMod_boss_mana = StatModifierRaid25M_Boss_Mana;
+                        statMod_boss_armor = StatModifierRaid25M_Boss_Armor;
+                        statMod_boss_damage = StatModifierRaid25M_Boss_Damage;
                         break;
                     case 40:
                         statMod_global = StatModifierRaid40M_Global;
@@ -1287,6 +1426,10 @@ public:
                         statMod_armor = StatModifierRaid40M_Armor;
                         statMod_damage = StatModifierRaid40M_Damage;
                         statMod_boss_global = StatModifierRaid40M_Boss_Global;
+                        statMod_boss_health = StatModifierRaid40M_Boss_Health;
+                        statMod_boss_mana = StatModifierRaid40M_Boss_Mana;
+                        statMod_boss_armor = StatModifierRaid40M_Boss_Armor;
+                        statMod_boss_damage = StatModifierRaid40M_Boss_Damage;
                         break;
                     default:
                         statMod_global = StatModifierRaid_Global;
@@ -1295,6 +1438,10 @@ public:
                         statMod_armor = StatModifierRaid_Armor;
                         statMod_damage = StatModifierRaid_Damage;
                         statMod_boss_global = StatModifierRaid_Boss_Global;
+                        statMod_boss_health = StatModifierRaid_Boss_Health;
+                        statMod_boss_mana = StatModifierRaid_Boss_Mana;
+                        statMod_boss_armor = StatModifierRaid_Boss_Armor;
+                        statMod_boss_damage = StatModifierRaid_Boss_Damage;
                 }
             }
             else
@@ -1305,41 +1452,83 @@ public:
                 statMod_armor = StatModifier_Armor;
                 statMod_damage = StatModifier_Damage;
                 statMod_boss_global = StatModifier_Boss_Global;
+                statMod_boss_health = StatModifier_Boss_Health;
+                statMod_boss_mana = StatModifier_Boss_Mana;
+                statMod_boss_armor = StatModifier_Boss_Armor;
+                statMod_boss_damage = StatModifier_Boss_Damage;
             }
         }
 
-        // Per map ID overrides replace the above settings, if set
-        if (hasStatModifierOverride(mapId))
+        // Boss modifiers
+        if (creature->IsDungeonBoss())
         {
-            AutoBalanceStatModifiers* myStatModifierOverrides = &statModifierOverrides[mapId];
+            // Start with the settings determined above
+            // AutoBalance.StatModifier*.Boss.<stat>
+            if (creature->IsDungeonBoss())
+            {
+                statMod_global = statMod_boss_global;
+                statMod_health = statMod_boss_health;
+                statMod_mana = statMod_boss_mana;
+                statMod_armor = statMod_boss_armor;
+                statMod_damage = statMod_boss_damage;
+            }
 
-            if (myStatModifierOverrides->global != -1)      { statMod_global =      myStatModifierOverrides->global;      }
-            if (myStatModifierOverrides->health != -1)      { statMod_health =      myStatModifierOverrides->health;      }
-            if (myStatModifierOverrides->mana != -1)        { statMod_mana =        myStatModifierOverrides->mana;        }
-            if (myStatModifierOverrides->armor != -1)       { statMod_armor =       myStatModifierOverrides->armor;       }
-            if (myStatModifierOverrides->damage != -1)      { statMod_damage =      myStatModifierOverrides->damage;      }
-            if (myStatModifierOverrides->boss_global != -1) { statMod_boss_global = myStatModifierOverrides->boss_global; }
+            // Per-instance boss overrides
+            // AutoBalance.StatModifier.Boss.PerInstance
+            if (creature->IsDungeonBoss() && hasStatModifierBossOverride(mapId))
+            {
+                AutoBalanceStatModifiers* myStatModifierBossOverrides = &statModifierBossOverrides[mapId];
+
+                if (myStatModifierBossOverrides->global != -1)      { statMod_global =      myStatModifierBossOverrides->global;      }
+                if (myStatModifierBossOverrides->health != -1)      { statMod_health =      myStatModifierBossOverrides->health;      }
+                if (myStatModifierBossOverrides->mana != -1)        { statMod_mana =        myStatModifierBossOverrides->mana;        }
+                if (myStatModifierBossOverrides->armor != -1)       { statMod_armor =       myStatModifierBossOverrides->armor;       }
+                if (myStatModifierBossOverrides->damage != -1)      { statMod_damage =      myStatModifierBossOverrides->damage;      }
+            }
+        }
+        // Non-boss modifiers
+        else
+        {
+            // Per-instance non-boss overrides
+            // AutoBalance.StatModifier.PerInstance
+            if (hasStatModifierOverride(mapId))
+            {
+                AutoBalanceStatModifiers* myStatModifierOverrides = &statModifierOverrides[mapId];
+
+                if (myStatModifierOverrides->global != -1)      { statMod_global =      myStatModifierOverrides->global;      }
+                if (myStatModifierOverrides->health != -1)      { statMod_health =      myStatModifierOverrides->health;      }
+                if (myStatModifierOverrides->mana != -1)        { statMod_mana =        myStatModifierOverrides->mana;        }
+                if (myStatModifierOverrides->armor != -1)       { statMod_armor =       myStatModifierOverrides->armor;       }
+                if (myStatModifierOverrides->damage != -1)      { statMod_damage =      myStatModifierOverrides->damage;      }
+            }
         }
 
-        // Calculate our starting multiplier before adjustments
+        // Per-creature modifiers applied last
+        // AutoBalance.StatModifier.PerCreature
+        if (hasStatModifierCreatureOverride(creatureTemplate->Entry))
+        {
+            AutoBalanceStatModifiers* myCreatureOverrides = &statModifierCreatureOverrides[creatureTemplate->Entry];
+
+            if (myCreatureOverrides->global != -1)      { statMod_global =      myCreatureOverrides->global;      }
+            if (myCreatureOverrides->health != -1)      { statMod_health =      myCreatureOverrides->health;      }
+            if (myCreatureOverrides->mana != -1)        { statMod_mana =        myCreatureOverrides->mana;        }
+            if (myCreatureOverrides->armor != -1)       { statMod_armor =       myCreatureOverrides->armor;       }
+            if (myCreatureOverrides->damage != -1)      { statMod_damage =      myCreatureOverrides->damage;      }
+        }
+
+        // #maththings 
         float diff = ((float)maxNumberOfPlayers/5)*1.5f;
-        defaultMultiplier = (tanh(((float)creatureABInfo->instancePlayerCount - inflectionValue) / diff) + 1.0f) / 2.0f;
 
         // For math reasons that I do not understand, curveCeiling needs to be adjusted to bring the actual multiplier
         // closer to the curveCeiling setting. Create an adjustment based on how much the ceiling should be changed at
         // the max players multiplier.
-        float curveCeilingAdjustment = curveCeiling / ((tanh(((float)maxNumberOfPlayers - inflectionValue) / diff) + 1.0f) / 2.0f);
+        float curveCeilingAdjustment = curveCeiling / (((tanh(((float)maxNumberOfPlayers - inflectionValue) / diff) + 1.0f) / 2.0f) * (curveCeiling - curveFloor) + curveFloor);
 
-        // Adjust the multiplier based on the configured floor and ceiling values
-        defaultMultiplier = (defaultMultiplier * (curveCeiling * curveCeilingAdjustment - curveFloor) + curveFloor);
-
+        // Adjust the multiplier based on the configured floor and ceiling values, plus the ceiling adjustment we just calculated
+        defaultMultiplier = ((tanh(((float)creatureABInfo->instancePlayerCount - inflectionValue) / diff) + 1.0f) / 2.0f) * (curveCeiling * curveCeilingAdjustment - curveFloor) + curveFloor;
 
         if (!sABScriptMgr->OnAfterDefaultMultiplier(creature, defaultMultiplier))
             return;
-
-        // If this is a boss, adjust the statMod global rate accordingly
-        if (creature->IsDungeonBoss())
-            statMod_global *= statMod_boss_global;
 
         //
         //  Health Scaling

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -864,7 +864,11 @@ class AutoBalance_AllMapScript : public AllMapScript
                             if (Player* playerHandle = playerIteration->GetSource())
                             {
                                 ChatHandler chatHandle = ChatHandler(playerHandle->GetSession());
-                                chatHandle.PSendSysMessage("|cffFF0000 [AutoBalance]|r|cffFF8000 %s entered the Instance %s. Auto setting player count to %u (Player Difficulty Offset = %u) |r", player->GetName().c_str(), map->GetMapName(), mapABInfo->playerCount + PlayerCountDifficultyOffset, PlayerCountDifficultyOffset);
+                                auto instanceMap = ((InstanceMap*)sMapMgr->FindMap(map->GetId(), map->GetInstanceId()));
+
+                                std::string instanceDifficulty; if (instanceMap->IsHeroic()) instanceDifficulty = "Heroic"; else instanceDifficulty = "Normal";
+
+                                chatHandle.PSendSysMessage("|cffFF0000 [AutoBalance]|r|cffFF8000 %s enters %s (%u-player %s). Player count set to %u (Player Difficulty Offset = %u) |r", player->GetName().c_str(), map->GetMapName(), instanceMap->GetMaxPlayers(), instanceDifficulty, mapABInfo->playerCount + PlayerCountDifficultyOffset, PlayerCountDifficultyOffset);
                             }
                         }
                     }
@@ -1118,77 +1122,67 @@ public:
 
         if (instanceMap->IsHeroic())
         {
-            if (instanceMap->IsRaid())
+            switch (maxNumberOfPlayers)
             {
-                switch (instanceMap->GetMaxPlayers())
-                {
-                    case 10:
-                        inflectionValue *= InflectionPointRaid10MHeroic;
-                        curveFloor = InflectionPointRaid10MHeroicCurveFloor;
-                        curveCeiling = InflectionPointRaid10MHeroicCurveCeiling;
-                        break;
-                    case 25:
-                        inflectionValue *= InflectionPointRaid25MHeroic;
-                        curveFloor = InflectionPointRaid25MHeroicCurveFloor;
-                        curveCeiling = InflectionPointRaid25MHeroicCurveCeiling;
-                        break;
-                    default:
-                        inflectionValue *= InflectionPointRaidHeroic;
-                        curveFloor = InflectionPointRaidHeroicCurveFloor;
-                        curveCeiling = InflectionPointRaidHeroicCurveCeiling;;
-                }
-            }
-            else
-            {
-                inflectionValue *= InflectionPointHeroic;
-                curveFloor = InflectionPointHeroicCurveFloor;
-                curveCeiling = InflectionPointHeroicCurveCeiling;
+                case 1 ... 5:
+                    inflectionValue *= InflectionPointHeroic;
+                    curveFloor = InflectionPointHeroicCurveFloor;
+                    curveCeiling = InflectionPointHeroicCurveCeiling;
+                    break;
+                case 10:
+                    inflectionValue *= InflectionPointRaid10MHeroic;
+                    curveFloor = InflectionPointRaid10MHeroicCurveFloor;
+                    curveCeiling = InflectionPointRaid10MHeroicCurveCeiling;
+                    break;
+                case 25:
+                    inflectionValue *= InflectionPointRaid25MHeroic;
+                    curveFloor = InflectionPointRaid25MHeroicCurveFloor;
+                    curveCeiling = InflectionPointRaid25MHeroicCurveCeiling;
+                    break;
+                default:
+                    inflectionValue *= InflectionPointRaidHeroic;
+                    curveFloor = InflectionPointRaidHeroicCurveFloor;
+                    curveCeiling = InflectionPointRaidHeroicCurveCeiling;
             }
         }
         else
         {
-            if (instanceMap->IsRaid())
+            switch (maxNumberOfPlayers)
             {
-                switch (instanceMap->GetMaxPlayers())
-                {
-                    case 10:
-                        inflectionValue *= InflectionPointRaid10M;
-                        curveFloor = InflectionPointRaid10MCurveFloor;
-                        curveCeiling = InflectionPointRaid10MCurveCeiling;
-
-                        break;
-                    case 15:
-                        inflectionValue *= InflectionPointRaid15M;
-                        curveFloor = InflectionPointRaid15MCurveFloor;
-                        curveCeiling = InflectionPointRaid15MCurveCeiling;
-
-                        break;
-                    case 20:
-                        inflectionValue *= InflectionPointRaid20M;
-                        curveFloor = InflectionPointRaid20MCurveFloor;
-                        curveCeiling = InflectionPointRaid20MCurveCeiling;
-                        break;
-                    case 25:
-                        inflectionValue *= InflectionPointRaid25M;
-                        curveFloor = InflectionPointRaid25MCurveFloor;
-                        curveCeiling = InflectionPointRaid25MCurveCeiling;
-                        break;
-                    case 40:
-                        inflectionValue *= InflectionPointRaid40M;
-                        curveFloor = InflectionPointRaid40MCurveFloor;
-                        curveCeiling = InflectionPointRaid40MCurveCeiling;
-                        break;
-                    default:
-                        inflectionValue *= InflectionPointRaid;
-                        curveFloor = InflectionPointRaidCurveFloor;
-                        curveCeiling = InflectionPointRaidCurveCeiling;
-                }
-            }
-            else
-            {
-                inflectionValue *= InflectionPoint;
-                curveFloor = InflectionPointCurveFloor;
-                curveCeiling = InflectionPointCurveCeiling;
+                case 1 ... 5:
+                    inflectionValue *= InflectionPoint;
+                    curveFloor = InflectionPointCurveFloor;
+                    curveCeiling = InflectionPointCurveCeiling;
+                    break;
+                case 10:
+                    inflectionValue *= InflectionPointRaid10M;
+                    curveFloor = InflectionPointRaid10MCurveFloor;
+                    curveCeiling = InflectionPointRaid10MCurveCeiling;
+                    break;
+                case 15:
+                    inflectionValue *= InflectionPointRaid15M;
+                    curveFloor = InflectionPointRaid15MCurveFloor;
+                    curveCeiling = InflectionPointRaid15MCurveCeiling;
+                    break;
+                case 20:
+                    inflectionValue *= InflectionPointRaid20M;
+                    curveFloor = InflectionPointRaid20MCurveFloor;
+                    curveCeiling = InflectionPointRaid20MCurveCeiling;
+                    break;
+                case 25:
+                    inflectionValue *= InflectionPointRaid25M;
+                    curveFloor = InflectionPointRaid25MCurveFloor;
+                    curveCeiling = InflectionPointRaid25MCurveCeiling;
+                    break;
+                case 40:
+                    inflectionValue *= InflectionPointRaid40M;
+                    curveFloor = InflectionPointRaid40MCurveFloor;
+                    curveCeiling = InflectionPointRaid40MCurveCeiling;
+                    break;
+                default:
+                    inflectionValue *= InflectionPointRaid;
+                    curveFloor = InflectionPointRaidCurveFloor;
+                    curveCeiling = InflectionPointRaidCurveCeiling;
             }
         }
 
@@ -1218,53 +1212,45 @@ public:
             // Determine the correct boss inflection multiplier
             if (instanceMap->IsHeroic())
             {
-                if (instanceMap->IsRaid())
+                switch (maxNumberOfPlayers)
                 {
-                    switch (instanceMap->GetMaxPlayers())
-                    {
-                        case 10:
-                            bossInflectionPointMultiplier = InflectionPointRaid10MHeroicBoss;
-                            break;
-                        case 25:
-                            bossInflectionPointMultiplier = InflectionPointRaid25MHeroicBoss;
-                            break;
-                        default:
-                            bossInflectionPointMultiplier = InflectionPointRaidHeroicBoss;
-                    }
-                }
-                else
-                {
-                    bossInflectionPointMultiplier = InflectionPointHeroicBoss;
+                    case 1 ... 5:
+                        bossInflectionPointMultiplier = InflectionPointHeroicBoss;
+                        break;
+                    case 10:
+                        bossInflectionPointMultiplier = InflectionPointRaid10MHeroicBoss;
+                        break;
+                    case 25:
+                        bossInflectionPointMultiplier = InflectionPointRaid25MHeroicBoss;
+                        break;
+                    default:
+                        bossInflectionPointMultiplier = InflectionPointRaidHeroicBoss;
                 }
             }
             else
             {
-                if (instanceMap->IsRaid())
+                switch (maxNumberOfPlayers)
                 {
-                    switch (instanceMap->GetMaxPlayers())
-                    {
-                        case 10:
-                            bossInflectionPointMultiplier = InflectionPointRaid10MBoss;
-                            break;
-                        case 15:
-                            bossInflectionPointMultiplier = InflectionPointRaid15MBoss;
-                            break;
-                        case 20:
-                            bossInflectionPointMultiplier = InflectionPointRaid20MBoss;
-                            break;
-                        case 25:
-                            bossInflectionPointMultiplier = InflectionPointRaid25MBoss;
-                            break;
-                        case 40:
-                            bossInflectionPointMultiplier = InflectionPointRaid40MBoss;
-                            break;
-                        default:
-                            bossInflectionPointMultiplier = InflectionPointRaidBoss;
-                    }
-                }
-                else
-                {
-                    bossInflectionPointMultiplier = InflectionPointBoss;
+                    case 1 ... 5:
+                        bossInflectionPointMultiplier = InflectionPointBoss;
+                        break;
+                    case 10:
+                        bossInflectionPointMultiplier = InflectionPointRaid10MBoss;
+                        break;
+                    case 15:
+                        bossInflectionPointMultiplier = InflectionPointRaid15MBoss;
+                        break;
+                    case 20:
+                        bossInflectionPointMultiplier = InflectionPointRaid20MBoss;
+                        break;
+                    case 25:
+                        bossInflectionPointMultiplier = InflectionPointRaid25MBoss;
+                        break;
+                    case 40:
+                        bossInflectionPointMultiplier = InflectionPointRaid40MBoss;
+                        break;
+                    default:
+                        bossInflectionPointMultiplier = InflectionPointRaidBoss;
                 }
             }
 
@@ -1296,168 +1282,152 @@ public:
         //
 
         // Calculate stat modifiers
-        float statMod_global =      1.0f;
-        float statMod_health =      1.0f;
-        float statMod_mana =        1.0f;
-        float statMod_armor =       1.0f;
-        float statMod_damage =      1.0f;
-        float statMod_boss_global = 1.0f;
-        float statMod_boss_health = 1.0f;
-        float statMod_boss_mana =   1.0f;
-        float statMod_boss_armor =  1.0f;
-        float statMod_boss_damage = 1.0f;
+        float statMod_global, statMod_health, statMod_mana, statMod_armor, statMod_damage;
+        float statMod_boss_global, statMod_boss_health, statMod_boss_mana, statMod_boss_armor, statMod_boss_damage;
 
         // Apply the per-instance-type modifiers first
-        if (instanceMap->IsHeroic())
-        {
-            if (instanceMap->IsRaid())
-            {
-                switch (instanceMap->GetMaxPlayers())
-                {
-                    case 10:
-                        statMod_global = StatModifierRaid10MHeroic_Global;
-                        statMod_health = StatModifierRaid10MHeroic_Health;
-                        statMod_mana = StatModifierRaid10MHeroic_Mana;
-                        statMod_armor = StatModifierRaid10MHeroic_Armor;
-                        statMod_damage = StatModifierRaid10MHeroic_Damage;
-                        statMod_boss_global = StatModifierRaid10MHeroic_Boss_Global;
-                        statMod_boss_health = StatModifierRaid10MHeroic_Boss_Health;
-                        statMod_boss_mana = StatModifierRaid10MHeroic_Boss_Mana;
-                        statMod_boss_armor = StatModifierRaid10MHeroic_Boss_Armor;
-                        statMod_boss_damage = StatModifierRaid10MHeroic_Boss_Damage;
-                        break;
-                    case 25:
-                        statMod_global = StatModifierRaid25MHeroic_Global;
-                        statMod_health = StatModifierRaid25MHeroic_Health;
-                        statMod_mana = StatModifierRaid25MHeroic_Mana;
-                        statMod_armor = StatModifierRaid25MHeroic_Armor;
-                        statMod_damage = StatModifierRaid25MHeroic_Damage;
-                        statMod_boss_global = StatModifierRaid25MHeroic_Boss_Global;
-                        statMod_boss_health = StatModifierRaid25MHeroic_Boss_Health;
-                        statMod_boss_mana = StatModifierRaid25MHeroic_Boss_Mana;
-                        statMod_boss_armor = StatModifierRaid25MHeroic_Boss_Armor;
-                        statMod_boss_damage = StatModifierRaid25MHeroic_Boss_Damage;
-                        break;
-                    default:
-                        statMod_global = StatModifierRaidHeroic_Global;
-                        statMod_health = StatModifierRaidHeroic_Health;
-                        statMod_mana = StatModifierRaidHeroic_Mana;
-                        statMod_armor = StatModifierRaidHeroic_Armor;
-                        statMod_damage = StatModifierRaidHeroic_Damage;
-                        statMod_boss_global = StatModifierRaidHeroic_Global;
-                        statMod_boss_health = StatModifierRaidHeroic_Health;
-                        statMod_boss_mana = StatModifierRaidHeroic_Mana;
-                        statMod_boss_armor = StatModifierRaidHeroic_Armor;
-                        statMod_boss_damage = StatModifierRaidHeroic_Damage;
-                }
-            }
-            else
-            {
-                statMod_global = StatModifierHeroic_Global;
-                statMod_health = StatModifierHeroic_Health;
-                statMod_mana = StatModifierHeroic_Mana;
-                statMod_armor = StatModifierHeroic_Armor;
-                statMod_damage = StatModifierHeroic_Damage;
-                statMod_boss_global = StatModifierHeroic_Boss_Global;
-                statMod_boss_health = StatModifierHeroic_Boss_Health;
-                statMod_boss_mana = StatModifierHeroic_Boss_Mana;
-                statMod_boss_armor = StatModifierHeroic_Boss_Armor;
-                statMod_boss_damage = StatModifierHeroic_Boss_Damage;
-            }
-        }
-        else
-        {
-            if (instanceMap->IsRaid())
-            {
-                switch (instanceMap->GetMaxPlayers())
-                {
-                    case 10:
-                        statMod_global = StatModifierRaid10M_Global;
-                        statMod_health = StatModifierRaid10M_Health;
-                        statMod_mana = StatModifierRaid10M_Mana;
-                        statMod_armor = StatModifierRaid10M_Armor;
-                        statMod_damage = StatModifierRaid10M_Damage;
-                        statMod_boss_global = StatModifierRaid10M_Boss_Global;
-                        statMod_boss_health = StatModifierRaid10M_Boss_Health;
-                        statMod_boss_mana = StatModifierRaid10M_Boss_Mana;
-                        statMod_boss_armor = StatModifierRaid10M_Boss_Armor;
-                        statMod_boss_damage = StatModifierRaid10M_Boss_Damage;
-                        break;
-                    case 15:
-                        statMod_global = StatModifierRaid15M_Global;
-                        statMod_health = StatModifierRaid15M_Health;
-                        statMod_mana = StatModifierRaid15M_Mana;
-                        statMod_armor = StatModifierRaid15M_Armor;
-                        statMod_damage = StatModifierRaid15M_Damage;
-                        statMod_boss_global = StatModifierRaid15M_Boss_Global;
-                        statMod_boss_health = StatModifierRaid15M_Boss_Health;
-                        statMod_boss_mana = StatModifierRaid15M_Boss_Mana;
-                        statMod_boss_armor = StatModifierRaid15M_Boss_Armor;
-                        statMod_boss_damage = StatModifierRaid15M_Boss_Damage;
-                        break;
-                    case 20:
-                        statMod_global = StatModifierRaid20M_Global;
-                        statMod_health = StatModifierRaid20M_Health;
-                        statMod_mana = StatModifierRaid20M_Mana;
-                        statMod_armor = StatModifierRaid20M_Armor;
-                        statMod_damage = StatModifierRaid20M_Damage;
-                        statMod_boss_global = StatModifierRaid20M_Boss_Global;
-                        statMod_boss_health = StatModifierRaid20M_Boss_Health;
-                        statMod_boss_mana = StatModifierRaid20M_Boss_Mana;
-                        statMod_boss_armor = StatModifierRaid20M_Boss_Armor;
-                        statMod_boss_damage = StatModifierRaid20M_Boss_Damage;
-                        break;
-                    case 25:
-                        statMod_global = StatModifierRaid25M_Global;
-                        statMod_health = StatModifierRaid25M_Health;
-                        statMod_mana = StatModifierRaid25M_Mana;
-                        statMod_armor = StatModifierRaid25M_Armor;
-                        statMod_damage = StatModifierRaid25M_Damage;
-                        statMod_boss_global = StatModifierRaid25M_Boss_Global;
-                        statMod_boss_health = StatModifierRaid25M_Boss_Health;
-                        statMod_boss_mana = StatModifierRaid25M_Boss_Mana;
-                        statMod_boss_armor = StatModifierRaid25M_Boss_Armor;
-                        statMod_boss_damage = StatModifierRaid25M_Boss_Damage;
-                        break;
-                    case 40:
-                        statMod_global = StatModifierRaid40M_Global;
-                        statMod_health = StatModifierRaid40M_Health;
-                        statMod_mana = StatModifierRaid40M_Mana;
-                        statMod_armor = StatModifierRaid40M_Armor;
-                        statMod_damage = StatModifierRaid40M_Damage;
-                        statMod_boss_global = StatModifierRaid40M_Boss_Global;
-                        statMod_boss_health = StatModifierRaid40M_Boss_Health;
-                        statMod_boss_mana = StatModifierRaid40M_Boss_Mana;
-                        statMod_boss_armor = StatModifierRaid40M_Boss_Armor;
-                        statMod_boss_damage = StatModifierRaid40M_Boss_Damage;
-                        break;
-                    default:
-                        statMod_global = StatModifierRaid_Global;
-                        statMod_health = StatModifierRaid_Health;
-                        statMod_mana = StatModifierRaid_Mana;
-                        statMod_armor = StatModifierRaid_Armor;
-                        statMod_damage = StatModifierRaid_Damage;
-                        statMod_boss_global = StatModifierRaid_Boss_Global;
-                        statMod_boss_health = StatModifierRaid_Boss_Health;
-                        statMod_boss_mana = StatModifierRaid_Boss_Mana;
-                        statMod_boss_armor = StatModifierRaid_Boss_Armor;
-                        statMod_boss_damage = StatModifierRaid_Boss_Damage;
-                }
-            }
-            else
-            {
-                statMod_global = StatModifier_Global;
-                statMod_health = StatModifier_Health;
-                statMod_mana = StatModifier_Mana;
-                statMod_armor = StatModifier_Armor;
-                statMod_damage = StatModifier_Damage;
-                statMod_boss_global = StatModifier_Boss_Global;
-                statMod_boss_health = StatModifier_Boss_Health;
-                statMod_boss_mana = StatModifier_Boss_Mana;
-                statMod_boss_armor = StatModifier_Boss_Armor;
-                statMod_boss_damage = StatModifier_Boss_Damage;
-            }
-        }
+		if (instanceMap->IsHeroic())
+		{
+			switch (maxNumberOfPlayers)
+			{
+			    case 1 ... 5:
+			        statMod_global = StatModifierHeroic_Global;
+			        statMod_health = StatModifierHeroic_Health;
+			        statMod_mana = StatModifierHeroic_Mana;
+			        statMod_armor = StatModifierHeroic_Armor;
+			        statMod_damage = StatModifierHeroic_Damage;
+			        statMod_boss_global = StatModifierHeroic_Boss_Global;
+			        statMod_boss_health = StatModifierHeroic_Boss_Health;
+			        statMod_boss_mana = StatModifierHeroic_Boss_Mana;
+			        statMod_boss_armor = StatModifierHeroic_Boss_Armor;
+			        statMod_boss_damage = StatModifierHeroic_Boss_Damage;
+			        break;
+			    case 10:
+                    statMod_global = StatModifierRaid10MHeroic_Global;
+                    statMod_health = StatModifierRaid10MHeroic_Health;
+                    statMod_mana = StatModifierRaid10MHeroic_Mana;
+                    statMod_armor = StatModifierRaid10MHeroic_Armor;
+                    statMod_damage = StatModifierRaid10MHeroic_Damage;
+                    statMod_boss_global = StatModifierRaid10MHeroic_Boss_Global;
+                    statMod_boss_health = StatModifierRaid10MHeroic_Boss_Health;
+                    statMod_boss_mana = StatModifierRaid10MHeroic_Boss_Mana;
+                    statMod_boss_armor = StatModifierRaid10MHeroic_Boss_Armor;
+                    statMod_boss_damage = StatModifierRaid10MHeroic_Boss_Damage;
+			        break;
+			    case 25:
+                    statMod_global = StatModifierRaid25MHeroic_Global;
+                    statMod_health = StatModifierRaid25MHeroic_Health;
+                    statMod_mana = StatModifierRaid25MHeroic_Mana;
+                    statMod_armor = StatModifierRaid25MHeroic_Armor;
+                    statMod_damage = StatModifierRaid25MHeroic_Damage;
+                    statMod_boss_global = StatModifierRaid25MHeroic_Boss_Global;
+                    statMod_boss_health = StatModifierRaid25MHeroic_Boss_Health;
+                    statMod_boss_mana = StatModifierRaid25MHeroic_Boss_Mana;
+                    statMod_boss_armor = StatModifierRaid25MHeroic_Boss_Armor;
+                    statMod_boss_damage = StatModifierRaid25MHeroic_Boss_Damage;
+                    break;
+			    default:
+                    statMod_global = StatModifierRaidHeroic_Global;
+                    statMod_health = StatModifierRaidHeroic_Health;
+                    statMod_mana = StatModifierRaidHeroic_Mana;
+                    statMod_armor = StatModifierRaidHeroic_Armor;
+                    statMod_damage = StatModifierRaidHeroic_Damage;
+                    statMod_boss_global = StatModifierRaidHeroic_Global;
+                    statMod_boss_health = StatModifierRaidHeroic_Health;
+                    statMod_boss_mana = StatModifierRaidHeroic_Mana;
+                    statMod_boss_armor = StatModifierRaidHeroic_Armor;
+                    statMod_boss_damage = StatModifierRaidHeroic_Damage;
+			}
+		}
+		else
+		{
+			switch (maxNumberOfPlayers)
+			{
+			    case 1 ... 5:
+			        statMod_global = StatModifier_Global;
+			        statMod_health = StatModifier_Health;
+			        statMod_mana = StatModifier_Mana;
+			        statMod_armor = StatModifier_Armor;
+			        statMod_damage = StatModifier_Damage;
+			        statMod_boss_global = StatModifier_Boss_Global;
+			        statMod_boss_health = StatModifier_Boss_Health;
+			        statMod_boss_mana = StatModifier_Boss_Mana;
+			        statMod_boss_armor = StatModifier_Boss_Armor;
+			        statMod_boss_damage = StatModifier_Boss_Damage;
+			        break;
+			    case 10:
+                    statMod_global = StatModifierRaid10M_Global;
+                    statMod_health = StatModifierRaid10M_Health;
+                    statMod_mana = StatModifierRaid10M_Mana;
+                    statMod_armor = StatModifierRaid10M_Armor;
+                    statMod_damage = StatModifierRaid10M_Damage;
+                    statMod_boss_global = StatModifierRaid10M_Boss_Global;
+                    statMod_boss_health = StatModifierRaid10M_Boss_Health;
+                    statMod_boss_mana = StatModifierRaid10M_Boss_Mana;
+                    statMod_boss_armor = StatModifierRaid10M_Boss_Armor;
+                    statMod_boss_damage = StatModifierRaid10M_Boss_Damage;
+                    break;
+			    case 15:
+                    statMod_global = StatModifierRaid15M_Global;
+                    statMod_health = StatModifierRaid15M_Health;
+                    statMod_mana = StatModifierRaid15M_Mana;
+                    statMod_armor = StatModifierRaid15M_Armor;
+                    statMod_damage = StatModifierRaid15M_Damage;
+                    statMod_boss_global = StatModifierRaid15M_Boss_Global;
+                    statMod_boss_health = StatModifierRaid15M_Boss_Health;
+                    statMod_boss_mana = StatModifierRaid15M_Boss_Mana;
+                    statMod_boss_armor = StatModifierRaid15M_Boss_Armor;
+                    statMod_boss_damage = StatModifierRaid15M_Boss_Damage;
+                    break;
+			    case 20:
+                    statMod_global = StatModifierRaid20M_Global;
+                    statMod_health = StatModifierRaid20M_Health;
+                    statMod_mana = StatModifierRaid20M_Mana;
+                    statMod_armor = StatModifierRaid20M_Armor;
+                    statMod_damage = StatModifierRaid20M_Damage;
+                    statMod_boss_global = StatModifierRaid20M_Boss_Global;
+                    statMod_boss_health = StatModifierRaid20M_Boss_Health;
+                    statMod_boss_mana = StatModifierRaid20M_Boss_Mana;
+                    statMod_boss_armor = StatModifierRaid20M_Boss_Armor;
+                    statMod_boss_damage = StatModifierRaid20M_Boss_Damage;
+                    break;
+			    case 25:
+                    statMod_global = StatModifierRaid25M_Global;
+                    statMod_health = StatModifierRaid25M_Health;
+                    statMod_mana = StatModifierRaid25M_Mana;
+                    statMod_armor = StatModifierRaid25M_Armor;
+                    statMod_damage = StatModifierRaid25M_Damage;
+                    statMod_boss_global = StatModifierRaid25M_Boss_Global;
+                    statMod_boss_health = StatModifierRaid25M_Boss_Health;
+                    statMod_boss_mana = StatModifierRaid25M_Boss_Mana;
+                    statMod_boss_armor = StatModifierRaid25M_Boss_Armor;
+                    statMod_boss_damage = StatModifierRaid25M_Boss_Damage;
+                    break;
+			    case 40:
+                    statMod_global = StatModifierRaid40M_Global;
+                    statMod_health = StatModifierRaid40M_Health;
+                    statMod_mana = StatModifierRaid40M_Mana;
+                    statMod_armor = StatModifierRaid40M_Armor;
+                    statMod_damage = StatModifierRaid40M_Damage;
+                    statMod_boss_global = StatModifierRaid40M_Boss_Global;
+                    statMod_boss_health = StatModifierRaid40M_Boss_Health;
+                    statMod_boss_mana = StatModifierRaid40M_Boss_Mana;
+                    statMod_boss_armor = StatModifierRaid40M_Boss_Armor;
+                    statMod_boss_damage = StatModifierRaid40M_Boss_Damage;
+                    break;
+			    default:
+                    statMod_global = StatModifierRaid_Global;
+                    statMod_health = StatModifierRaid_Health;
+                    statMod_mana = StatModifierRaid_Mana;
+                    statMod_armor = StatModifierRaid_Armor;
+                    statMod_damage = StatModifierRaid_Damage;
+                    statMod_boss_global = StatModifierRaid_Boss_Global;
+                    statMod_boss_health = StatModifierRaid_Boss_Health;
+                    statMod_boss_mana = StatModifierRaid_Boss_Mana;
+                    statMod_boss_armor = StatModifierRaid_Boss_Armor;
+                    statMod_boss_damage = StatModifierRaid_Boss_Damage;
+			}
+		}
 
         // Boss modifiers
         if (creature->IsDungeonBoss())
@@ -1621,7 +1591,7 @@ public:
             else {
                 newDmgBase=creatureStats->BaseDamage[2];
                 // special increasing for end-game contents
-                if (LevelEndGameBoost && !creature->GetMap()->IsRaid()) {
+                if (LevelEndGameBoost && maxNumberOfPlayers <= 5) {
                     newDmgBase *= creatureABInfo->selectedLevel >= 75 && originalLevel < 75 ? float(creatureABInfo->selectedLevel-70) * 0.3f : 1;
                 }
             }
@@ -1835,7 +1805,7 @@ public:
         if (playerList.IsEmpty())
             return;
 
-        uint32 reward = map->IsRaid() ? rewardRaid : rewardDungeon;
+        uint32 reward = map->ToInstanceMap()->GetMaxPlayers() > 5 ? rewardRaid : rewardDungeon;
         if (!reward)
             return;
 

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -1201,7 +1201,7 @@ public:
         {
             switch (maxNumberOfPlayers)
             {
-                case 1 ... 5:
+                case 5:
                     inflectionValue *= InflectionPointHeroic;
                     curveFloor = InflectionPointHeroicCurveFloor;
                     curveCeiling = InflectionPointHeroicCurveCeiling;
@@ -1226,7 +1226,7 @@ public:
         {
             switch (maxNumberOfPlayers)
             {
-                case 1 ... 5:
+                case 5:
                     inflectionValue *= InflectionPoint;
                     curveFloor = InflectionPointCurveFloor;
                     curveCeiling = InflectionPointCurveCeiling;
@@ -1291,7 +1291,7 @@ public:
             {
                 switch (maxNumberOfPlayers)
                 {
-                    case 1 ... 5:
+                    case 5:
                         bossInflectionPointMultiplier = InflectionPointHeroicBoss;
                         break;
                     case 10:
@@ -1308,7 +1308,7 @@ public:
             {
                 switch (maxNumberOfPlayers)
                 {
-                    case 1 ... 5:
+                    case 5:
                         bossInflectionPointMultiplier = InflectionPointBoss;
                         break;
                     case 10:
@@ -1367,7 +1367,7 @@ public:
 		{
 			switch (maxNumberOfPlayers)
 			{
-			    case 1 ... 5:
+			    case 5:
 			        statMod_global = StatModifierHeroic_Global;
 			        statMod_health = StatModifierHeroic_Health;
 			        statMod_mana = StatModifierHeroic_Mana;
@@ -1432,7 +1432,7 @@ public:
 		{
 			switch (maxNumberOfPlayers)
 			{
-			    case 1 ... 5:
+			    case 5:
 			        statMod_global = StatModifier_Global;
 			        statMod_health = StatModifier_Health;
 			        statMod_mana = StatModifier_Mana;


### PR DESCRIPTION
### Features
This PR gives more control to the administrator as to how to scale creatures in instances. This is done in several ways.

- create new raid settings for 15/20/40 player raids
- create `CurveFloor` and `CurveCeiling` settings per instance size to raise the floor or lower the ceiling of the multiplier curve
    - CurveFloor can be raised to prevent lower player counts from being too easy when higher InflectionPoint values are used
    - CurveCeiling can be lowered to allow a different multiplier than 1.0 at max players. It can also be raised above 1.0 to increase difficulty across all player counts in a non-linear way.
- deprecate `BossInflectionMult` in favor of settings for each instance type (dungeon, H.dungeon, raid, H.raid) or even each instance size.
    - the old setting is still used if present for backwards-compatibility with old settings files (with console warning)
- create new Stat Modifier settings that replace 'AutoBalance.rate.*' values. Settings can be applied per-raid type or per instance ID, boss or non-boss.
    - the old setting is still used if present for backwards-compatibility with old settings files (with console warning)
    - add `CCDuration` setting to tweak the duration of CC effects on players
- allow per-creature Stat Modifiers
- correctly propagate "default" raid settings down to raid sizes that are not customized (per-player-count customizations are now optional)

### Fixes
- fixes #101 (thanks @duncrafter !)

### Cleanup and Improvements
In addition, I did some general cleanup and reorganizing to better reflect the latest structure of the module.
- add images and [interactive spreadsheet](https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy) to aid understanding about how difficulty settings work
- enhance/reword existing variable descriptions based on actual functionality
- reorder configuration file and add headers to better connect related settings
- create unified explanation of InflectionPoint settings
- add new `.ab` command as a shorter version of `.autobalance`

### Testing
I am successfully running the updated module on my personal AzerothCore server. Using AC revision [f2e01028c](https://github.com/azerothcore/azerothcore-wotlk/commit/f2e01028c).

I tested in the following instances to ensure that the default settings were being applied correctly and that the multipliers match my [inflection point spreadsheet](https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/edit?usp=sharing).
- Scarlet Monastery (5-player dungeon, `InflectionPoint`)
- Shattered Halls (5-player heroic, `InflectionPointHeroic`)
- Molten Core (40-player normal, `InflectionPointRaid`)
- Icecrown Citadel (25-player heroic, `InflectionPointRaidHeroic`)

### TODO
The module's features as stated above are complete. However, I have some other additional features I'd be interested in adding:
- ~~add per-instance overrides for `CurveFloor` and `CurveCeiling`~~ Done!
- ~~make `rate` settings per instance type and player count too~~ Done!
- allow enabling/disabling of stat scaling on a per-instance-type basis
- rework override settings to be able to set any override settings for a map ID in one place (easy in Python, less easy in C++)
- figure out why there is ~~5%~~ 1% error between the set `CurveFloor`/`CurveCeiling` and the actual calculated ones. ~~Currently handling by statically setting the multiplier to `CurveCeiling` when max players are in the instance.~~ Close enough to be perfectly usable, but not perfect.
- allow user to set the multiplier value for 1-player to set the curve floor rather than the value for 0 players. I don't math so good, so not sure how to accomplish this yet.