### PR TITLE
 Remove `AutoBalance.DungeonsOnly`, replace with better `AutoBalance.Enable.*` settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ nbproject/
 *.kate-swp
 .idea
 cmake-build-debug
+.vscode
 
 #
 # Eclipse

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -1,24 +1,34 @@
 [worldserver]
+##########################
+#
+# Enable Settings
+#
+##########################
 
 #
-###################################################################################################
-
-###################################################################################################
-#
-# AUTOBALANCE ANNOUNCE
-#
-#     AutoBalanceAnnounce.enable
-#        Announce the module on login if it is enabled
+#     AutoBalance.Enable
+#        Enable/Disable all features globally. If this setting is off, all settings after this one do not take effect.
 #        Default:     1 (1 = ON, 0 = OFF)
-AutoBalanceAnnounce.enable=1
+AutoBalance.Enable.Global=1
 
 #
-# AUTOBALANCE OPTIONS
-#
-#     AutoBalance.enable
-#        Enable/Disable the autobalance system
+#     AutoBalance.Enabled.*
+#        Enable/Disable all features for each instance size and difficulty.
+#        If an instance size is set to 0 here, none of the other settings for that instance size will take effect.
 #        Default:     1 (1 = ON, 0 = OFF)
-AutoBalance.enable=1
+#
+AutoBalance.Enable.5M=1
+AutoBalance.Enable.10M=1
+AutoBalance.Enable.15M=1
+AutoBalance.Enable.20M=1
+AutoBalance.Enable.25M=1
+AutoBalance.Enable.40M=1
+AutoBalance.Enable.OtherNormal=1
+
+AutoBalance.Enable.5MHeroic=1
+AutoBalance.Enable.10MHeroic=1
+AutoBalance.Enable.25MHeroic=1
+AutoBalance.Enable.OtherHeroic=1
 
 ##########################
 #
@@ -42,7 +52,7 @@ AutoBalance.enable=1
 #        CurveFloor
 #           When the curve to determine the enemy multiplier is calculated, start the curve at this value.
 #
-#           This allows you to make enemies have higher stats for lower player counts without adversely affecting the stats of 
+#           This allows you to make enemies have higher stats for lower player counts without adversely affecting the stats of
 #           higher player counts. Applied before `AutoBalance.StatModifier*` values.
 #
 #           Value may be negative if needed to achieve your desired curve.
@@ -67,7 +77,7 @@ AutoBalance.enable=1
 #           Default: 1.0
 #
 #       BossModifier
-#           InflectionPoint is multiplied by this value for creatures considered dungeon bosses (from dungeons or raids). 
+#           InflectionPoint is multiplied by this value for creatures considered dungeon bosses (from dungeons or raids).
 #           It is a multiplier, not a new Inflection Point. Values higher than 1.0 will make enemies easier at lower player
 #           counts while lower than 1.0 will make enemies easier at lower player counts.
 #
@@ -108,8 +118,8 @@ AutoBalance.InflectionPointRaidHeroic.CurveCeiling=1.0
 AutoBalance.InflectionPointRaidHeroic.BossModifier=1.0
 
 ###
-### By default, all instances use the settings configured above. To customize settings for 
-### a particular instance size or difficulty, set the variables below. If the variable is 
+### By default, all instances use the settings configured above. To customize settings for
+### a particular instance size or difficulty, set the variables below. If the variable is
 ### blank, the broader settings above will apply.
 ###
 
@@ -161,7 +171,7 @@ AutoBalance.InflectionPointRaid40M.BossModifier=
 #
 #        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
 #
-#        Specifying a value of `-1` will skip overriding of that value. For instances not listed, the default inflection value for the instance's 
+#        Specifying a value of `-1` will skip overriding of that value. For instances not listed, the default inflection value for the instance's
 #        difficulty and size will be used. You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
 #
 #        Format: "[InstanceID] [InflectionPoint] [CurveFloor] [CurveCeiling], [InstanceID] [InflectionPoint] [CurveFloor] [CurveCeiling], ..."
@@ -175,7 +185,7 @@ AutoBalance.InflectionPoint.PerInstance=""
 #
 #     AutoBalance.InflectionPoint.Boss.PerInstance
 #        Sets Inflection Point settings for all bosses in specific `InstanceID`s. Note that the first value is "InflectionPointMultiplier", which behaves
-#        identically to the BossModifier setting. The "normal" inflection point is multiplied by this value for bosses. To better understand this effect, 
+#        identically to the BossModifier setting. The "normal" inflection point is multiplied by this value for bosses. To better understand this effect,
 #        see the interactive spreadsheet.
 #
 #        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
@@ -218,10 +228,10 @@ AutoBalance.playerCountDifficultyOffset=0
 #        The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given instance.
 #
 #        Global
-#           Multiply the other four settings by this value. Allows you to increase all the stats (health, mana, armor, 
+#           Multiply the other four settings by this value. Allows you to increase all the stats (health, mana, armor,
 #           damage) with a single adjustment. Both the global value and the stat-specific value are used at the same time.
 #
-#           Example: If "Global" is 0.5, and "Health" is 1.5, the health of the creature will be multiplied by 0.75 of 
+#           Example: If "Global" is 0.5, and "Health" is 1.5, the health of the creature will be multiplied by 0.75 of
 #                    its value (after adjusting for the number of players).
 #
 #           Default: 1.0
@@ -232,7 +242,7 @@ AutoBalance.playerCountDifficultyOffset=0
 #           Default: 1.0
 #
 #        Boss.Global | Boss.Health | Boss.Mana | Boss.Armor | Boss.Damage
-#           Sets a SEPARATE stat multiplier for bosses. Is NOT affected by the non-boss modifiers. Only applies to creatures 
+#           Sets a SEPARATE stat multiplier for bosses. Is NOT affected by the non-boss modifiers. Only applies to creatures
 #           considered instance bosses (from dungeons or raids).
 #
 #           Default: If not set for a given instance size/type, defaults to the dungeon/raid default values.
@@ -293,8 +303,8 @@ AutoBalance.StatModifierRaidHeroic.Boss.Armor=1.0
 AutoBalance.StatModifierRaidHeroic.Boss.Damage=1.0
 
 ###
-### By default, all instances use the settings configured above. To customize settings for 
-### a particular instance size or difficulty, set the variables below. If the variable is 
+### By default, all instances use the settings configured above. To customize settings for
+### a particular instance size or difficulty, set the variables below. If the variable is
 ### blank, the broader settings above will apply.
 ###
 
@@ -692,12 +702,6 @@ AutoBalance.DungeonScaleDownXP = 0
 #        Default:     0 (1 = ON, 0 = OFF)
 AutoBalance.DungeonScaleDownMoney = 0
 
-#
-#     AutoBalance.DungeonsOnly
-#        Only apply scaling changes to dungeons and raids
-#        Default:     1 (1 = ON, 0 = OFF)
-AutoBalance.DungeonsOnly=1
-
 ##########################
 #
 # Messages
@@ -757,15 +761,39 @@ AutoBalance.reward.dungeonToken = 47241
 #       Default:     1
 AutoBalance.reward.MinPlayerReward = 1
 
-# The following variables are deprecated and should not be used in new deployments.
+##########################
+#
+# Announcement
+#
+##########################
+
+#
+#     AutoBalanceAnnounce.enable
+#        Announce the module on login if it is enabled
+#        Default:     1 (1 = ON, 0 = OFF)
+AutoBalanceAnnounce.enable=1
+
+##########################
+#
+# Deprecated Settings
+#
+##########################
+
+# The following variables are deprecated and should not be used in new deployments. Their values should be left blank.
 # They will still be applied to support backwards compatability, but will be removed entirely in a future release.
 # Their entire functionality (and more) has been moved to new settings referenced in this config file.
 #
-#   AutoBalance.PerDungeonScaling
-#   AutoBalance.PerDungeonBossScaling
-#   AutoBalance.BossInflectionMult
-#   AutoBalance.rate.global
-#   AutoBalance.rate.health
-#   AutoBalance.rate.mana
-#   AutoBalance.rate.armor
-#   AutoBalance.rate.damage
+AutoBalance.enable=
+AutoBalance.PerDungeonScaling=
+AutoBalance.PerDungeonBossScaling=
+AutoBalance.BossInflectionMult=
+AutoBalance.rate.global=
+AutoBalance.rate.health=
+AutoBalance.rate.mana=
+AutoBalance.rate.armor=
+AutoBalance.rate.damage=
+
+# The following variables have been removed entirely and should not be used in a new or existing deployment.
+# Their values should be left blank.
+# Their entire functionality (and more) has been moved to new settings referenced in this config file.
+AutoBalance.DungeonsOnly=

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -433,13 +433,13 @@ AutoBalance.StatModifierRaid40M.Boss.Damage=
 #               If no value is set for a given instance type and player count, and the generic values that apply to that instance
 #               are also blank, CC duration will be unchanged.
 #
-#        Boss.Global | Boss.Health | Boss.Mana | Boss.Armor | Boss.Damage
-#           Sets a SEPARATE stat multiplier for bosses. Is NOT affected by the non-boss modifiers. Only applies to creatures
+#        Boss.CCDuration
+#           Sets a SEPARATE CCDuration multiplier for bosses. Is NOT affected by the non-boss modifiers. Only applies to creatures
 #           considered instance bosses (from dungeons or raids).
 #
-#           Default: If not set for a given instance size/type, defaults to the dungeon/raid default values.
-#
-#           To better understand this effect, see the interactive spreadsheet.
+#           Default: no value
+#               If no value is set for a given instance type and player count, and the generic values that apply to that instance
+#               are also blank, CC duration will be unchanged.
 #
 
 ### 5-player dungeons
@@ -728,7 +728,6 @@ AutoBalance.PlayerChangeNotify=1
 # REWARD SYSTEM (experimental)
 #
 ##########################
-
 
 #
 #   AutoBalance.reward.enable

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -813,9 +813,18 @@ class AutoBalance_UnitScript : public UnitScript
     }
 
     void OnAuraApply(Unit* unit, Aura* aura) override {
-        uint32 auraDuration = _Modifier_CCDuration(unit, aura->GetCaster(), aura);
-        aura->SetMaxDuration(auraDuration);
-        aura->SetDuration(auraDuration);
+        // Only if this aura has a duration
+        if (aura->GetDuration() > 0 || aura->GetMaxDuration() > 0)
+        {
+            uint32 auraDuration = _Modifier_CCDuration(unit, aura->GetCaster(), aura);
+
+            // only update if we decided to change it
+            if (auraDuration != (float)aura->GetDuration())
+            {
+                aura->SetMaxDuration(auraDuration);
+                aura->SetDuration(auraDuration);
+            }
+        }
     }
 
     uint32 _Modifer_DealDamage(Unit* target, Unit* attacker, uint32 damage)
@@ -859,6 +868,10 @@ class AutoBalance_UnitScript : public UnitScript
         if (!(!DungeonsOnly
                 || (target->GetMap()->IsDungeon() && caster->GetMap()->IsDungeon()) || (caster->GetMap()->IsBattleground()
                      && target->GetMap()->IsBattleground())))
+            return originalDuration;
+
+        // if the CCDurationMultiplier isn't set on this enemy
+        if (!((float)caster->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->CCDurationMultiplier > 0))
             return originalDuration;
 
         // if the aura was cast by a pet or summon, return the original duration

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -119,20 +119,21 @@ public:
     uint8 selectedLevel = 0;
     // this is used to detect creatures that update their entry
     uint32 entry = 0;
-    float DamageMultiplier;
-    float HealthMultiplier;
-    float ManaMultiplier;
-    float ArmorMultiplier;
-    float CCDurationMultiplier;
+    float DamageMultiplier = 1.0f;
+    float HealthMultiplier = 1.0f;
+    float ManaMultiplier = 1.0f;
+    float ArmorMultiplier = 1.0f;
+    float CCDurationMultiplier = 1.0f;
 };
 
 class AutoBalanceMapInfo : public DataMap::Base
 {
 public:
     AutoBalanceMapInfo() {}
-    AutoBalanceMapInfo(uint32 count, uint8 selLevel) : playerCount(count),mapLevel(selLevel) {}
+    AutoBalanceMapInfo(uint32 count, uint8 selLevel, bool enabled) : playerCount(count),mapLevel(selLevel),enabled(enabled) {}
     uint32 playerCount = 0;
     uint8 mapLevel = 0;
+    bool enabled = false;
 };
 
 class AutoBalanceStatModifiers : public DataMap::Base
@@ -172,8 +173,15 @@ static std::map<uint32, AutoBalanceStatModifiers> statModifierCreatureOverrides;
 // Another value TODO in player class for the party leader's value to determine dungeon difficulty.
 static int8 PlayerCountDifficultyOffset, LevelScaling, higherOffset, lowerOffset;
 static uint32 rewardRaid, rewardDungeon, MinPlayerReward;
-static bool enabled, LevelEndGameBoost, DungeonsOnly, PlayerChangeNotify, LevelUseDb, rewardEnabled, DungeonScaleDownXP, DungeonScaleDownMoney;
+static bool Announcement;
+static bool LevelEndGameBoost, PlayerChangeNotify, LevelUseDb, rewardEnabled, DungeonScaleDownXP, DungeonScaleDownMoney;
 static float MinHPModifier, MinManaModifier, MinDamageModifier, MinCCDurationModifier, MaxCCDurationModifier;
+
+// Enable.*
+static bool EnableGlobal;
+static bool Enable5M, Enable10M, Enable15M, Enable20M, Enable25M, Enable40M;
+static bool Enable5MHeroic, Enable10MHeroic, Enable25MHeroic;
+static bool EnableOtherNormal, EnableOtherHeroic;
 
 // InflectionPoint*
 static float InflectionPoint, InflectionPointCurveFloor, InflectionPointCurveCeiling, InflectionPointBoss;
@@ -351,6 +359,71 @@ bool hasStatModifierCreatureOverride(uint32 creatureId)
     return (statModifierCreatureOverrides.find(creatureId) != statModifierCreatureOverrides.end());
 }
 
+bool ShouldMapBeEnabled(Map* map)
+{
+    if (map->IsDungeon() || map->IsRaid())
+    {
+        // get the current instance map
+        auto instanceMap = ((InstanceMap*)sMapMgr->FindMap(map->GetId(), map->GetInstanceId()));
+
+        // if there wasn't one, then we're not in an instance
+        if (!instanceMap)
+        {
+            return false;
+        }
+
+        // get the max player count for the instance
+        auto maxPlayerCount = instanceMap->GetMaxPlayers();
+
+        // if the player count is less than 1, then we're not in an instance
+        if (maxPlayerCount < 1)
+        {
+            return false;
+        }
+
+        // use the configuration variables to determine if this instance type/size should have scaling enabled
+        if (instanceMap->IsHeroic())
+        {
+            switch (maxPlayerCount)
+            {
+                case 5:
+                    return Enable5MHeroic;
+                case 10:
+                    return Enable10MHeroic;
+                case 25:
+                    return Enable25MHeroic;
+                default:
+                    return EnableOtherHeroic;
+            }
+        }
+        else
+        {
+            switch (maxPlayerCount)
+            {
+                case 5:
+                    return Enable5M;
+                case 10:
+                    return Enable10M;
+                case 15:
+                    return Enable15M;
+                case 20:
+                    return Enable20M;
+                case 25:
+                    return Enable25M;
+                case 40:
+                    return Enable40M;
+                default:
+                    return EnableOtherNormal;
+            }
+        }
+    }
+    else
+    {
+        // we're not in a dungeon or a raid, we never scale
+        return false;
+    }
+}
+
 void LoadForcedCreatureIdsFromString(std::string creatureIds, int forcedPlayerCount) // Used for reading the string from the configuration file to for those creatures who need to be scaled for XX number of players.
 {
     std::string delimitedValue;
@@ -452,9 +525,33 @@ class AutoBalance_WorldScript : public WorldScript
             sConfigMgr->GetOption<std::string>("AutoBalance.StatModifier.PerCreature", "", false)
         );
 
-        enabled = sConfigMgr->GetOption<bool>("AutoBalance.enable", 1);
+        // AutoBalance.Enable.*
+        // Deprecated setting warning
+        if (sConfigMgr->GetOption<int>("AutoBalance.enable", -1, false) != -1)
+            LOG_WARN("server.loading", "mod-autobalance: deprecated value `AutoBalance.enable` defined in `AutoBalance.conf`. This variable will be removed in a future release. Please see `AutoBalance.conf.dist` for more details.");
+
+        EnableGlobal = sConfigMgr->GetOption<bool>("AutoBalance.Enable.Global", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false)); // `AutoBalance.enable` for backwards compatibility
+
+        Enable5M = sConfigMgr->GetOption<bool>("AutoBalance.Enable.5M", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        Enable10M = sConfigMgr->GetOption<bool>("AutoBalance.Enable.10M", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        Enable15M = sConfigMgr->GetOption<bool>("AutoBalance.Enable.15M", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        Enable20M = sConfigMgr->GetOption<bool>("AutoBalance.Enable.20M", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        Enable25M = sConfigMgr->GetOption<bool>("AutoBalance.Enable.25M", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        Enable40M = sConfigMgr->GetOption<bool>("AutoBalance.Enable.40M", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        EnableOtherNormal = sConfigMgr->GetOption<bool>("AutoBalance.Enable.OtherNormal", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+
+        Enable5MHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.5MHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        Enable10MHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.5MHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        Enable25MHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.5MHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        EnableOtherHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.5MHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+
+        // Deprecated setting warning
+        if (sConfigMgr->GetOption<int>("AutoBalance.DungeonsOnly", -1, false) != -1)
+            LOG_WARN("server.loading", "mod-autobalance: deprecated value `AutoBalance.DungeonsOnly` defined in `AutoBalance.conf`. This variable has been removed and has no effect. Please see `AutoBalance.conf.dist` for more details.");
+
+        // Misc Settings
+        // TODO: Organize and standardize variable names
         LevelEndGameBoost = sConfigMgr->GetOption<bool>("AutoBalance.LevelEndGameBoost", 1);
-        DungeonsOnly = sConfigMgr->GetOption<bool>("AutoBalance.DungeonsOnly", 1);
         PlayerChangeNotify = sConfigMgr->GetOption<bool>("AutoBalance.PlayerChangeNotify", 1);
         LevelUseDb = sConfigMgr->GetOption<bool>("AutoBalance.levelUseDbValuesWhenExists", 1);
         rewardEnabled = sConfigMgr->GetOption<bool>("AutoBalance.reward.enable", 1);
@@ -469,7 +566,7 @@ class AutoBalance_WorldScript : public WorldScript
         rewardDungeon = sConfigMgr->GetOption<uint32>("AutoBalance.reward.dungeonToken", 47241);
         MinPlayerReward = sConfigMgr->GetOption<float>("AutoBalance.reward.MinPlayerReward", 1);
 
-        // AutoBalance.InflectionPoint*
+        // InflectionPoint*
         // warn the console if deprecated values are detected
         if (sConfigMgr->GetOption<float>("AutoBalance.BossInflectionMult", false, false))
             LOG_WARN("server.loading", "mod-autobalance: deprecated value `AutoBalance.BossInflectionMult` defined in `AutoBalance.conf`. This variable will be removed in a future release. Please see `AutoBalance.conf.dist` for more details.");
@@ -529,7 +626,7 @@ class AutoBalance_WorldScript : public WorldScript
         InflectionPointRaid40MCurveCeiling =        sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid40M.CurveCeiling", InflectionPointRaidCurveCeiling, false);
         InflectionPointRaid40MBoss =                sConfigMgr->GetOption<float>("AutoBalance.InflectionPointRaid40M.BossModifier", InflectionPointRaidBoss, false);
 
-        // AutoBalance.StatModifier*
+        // StatModifier*
         // warn the console if deprecated values are detected
         if (sConfigMgr->GetOption<float>("AutoBalance.rate.global", false, false))
             LOG_WARN("server.loading", "mod-autobalance: deprecated value `AutoBalance.rate.global` defined in `AutoBalance.conf`. This variable will be removed in a future release. Please see `AutoBalance.conf.dist` for more details.");
@@ -713,6 +810,10 @@ class AutoBalance_WorldScript : public WorldScript
         MinDamageModifier = sConfigMgr->GetOption<float>("AutoBalance.MinDamageModifier", 0.01f);
         MinCCDurationModifier = sConfigMgr->GetOption<float>("AutoBalance.MinCCDurationModifier", 0.25f);
         MaxCCDurationModifier = sConfigMgr->GetOption<float>("AutoBalance.MaxCCDurationModifier", 1.0f);
+
+        // Announcement
+        Announcement = sConfigMgr->GetOption<bool>("AutoBalanceAnnounce.enable", true);
+
     }
 };
 
@@ -726,14 +827,14 @@ class AutoBalance_PlayerScript : public PlayerScript
 
         void OnLogin(Player *Player) override
         {
-            if ((sConfigMgr->GetOption<bool>("AutoBalanceAnnounce.enable", true)) && (sConfigMgr->GetOption<bool>("AutoBalance.enable", true))) {
+            if (EnableGlobal && Announcement) {
                 ChatHandler(Player->GetSession()).SendSysMessage("This server is running the |cff4CFF00AutoBalance |rmodule.");
             }
         }
 
         virtual void OnLevelChanged(Player* player, uint8 /*oldlevel*/) override
         {
-            if (!enabled || !player)
+            if (!EnableGlobal || !player)
                 return;
 
             if (LevelScaling == 0)
@@ -743,11 +844,16 @@ class AutoBalance_PlayerScript : public PlayerScript
 
             if (mapABInfo->mapLevel < player->getLevel())
                 mapABInfo->mapLevel = player->getLevel();
+
+
         }
 
         void OnGiveXP(Player* player, uint32& amount, Unit* victim, uint8 /*xpSource*/) override
         {
-            if (victim && DungeonScaleDownXP)
+            Map* map = player->GetMap();
+            AutoBalanceMapInfo *mapABInfo=map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+
+            if (victim && DungeonScaleDownXP && mapABInfo->enabled)
             {
                 Map* map = player->GetMap();
 
@@ -763,7 +869,10 @@ class AutoBalance_PlayerScript : public PlayerScript
 
         void OnBeforeLootMoney(Player* player, Loot* loot) override
         {
-            if (DungeonScaleDownMoney)
+            Map* map = player->GetMap();
+            AutoBalanceMapInfo *mapABInfo=map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+
+            if (DungeonScaleDownMoney && mapABInfo->enabled)
             {
                 Map* map = player->GetMap();
 
@@ -829,49 +938,73 @@ class AutoBalance_UnitScript : public UnitScript
 
     uint32 _Modifer_DealDamage(Unit* target, Unit* attacker, uint32 damage)
     {
-        if (!enabled)
+        // check that we're enabled globally, else return the original damage
+        if (!EnableGlobal)
             return damage;
 
+        // make sure we have an attacker, that its not a player, and that the attacker is in the world, else return the original damage
         if (!attacker || attacker->GetTypeId() == TYPEID_PLAYER || !attacker->IsInWorld())
             return damage;
 
+        // make sure we're in an instance, else return the original damage
+        if (
+            !(
+                (target->GetMap()->IsDungeon() && attacker->GetMap()->IsDungeon()) ||
+                (target->GetMap()->IsBattleground() && attacker->GetMap()->IsBattleground())
+            )
+           )
+            return damage;
+
+        // get the map's info to see if we're enabled
+        AutoBalanceMapInfo *targetMapInfo = target->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+        AutoBalanceMapInfo *attackerMapInfo = attacker->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+
+        // if either the target or the attacker's maps are not enabled, return the original damage
+        if (!targetMapInfo->enabled || !attackerMapInfo->enabled)
+            return damage;
+
+        // get the current creature's damage multiplier
         float damageMultiplier = attacker->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->DamageMultiplier;
 
+        // if it's the default of 1.0, return the original damage
         if (damageMultiplier == 1)
             return damage;
 
-        if (!(!DungeonsOnly
-                || (target->GetMap()->IsDungeon() && attacker->GetMap()->IsDungeon()) || (attacker->GetMap()->IsBattleground()
-                     && target->GetMap()->IsBattleground())))
-            return damage;
-
-
+        // if the attacker is under the control of the player, return the original damage
         if ((attacker->IsHunterPet() || attacker->IsPet() || attacker->IsSummon()) && attacker->IsControlledByPlayer())
             return damage;
 
+        // we are good to go, return the original damage times the multiplier
         return damage * damageMultiplier;
     }
 
     uint32 _Modifier_CCDuration(Unit* target, Unit* caster, Aura* aura)
     {
+        // store the original duration of the aura
         float originalDuration = (float)aura->GetDuration();
 
-        // only if enabled
-        if (!enabled)
+        // check that we're enabled globally, else return the original duration
+        if (!EnableGlobal)
             return originalDuration;
 
         // if the target isn't a player or the caster is a player, return the original duration
         if (!target->IsPlayer() || caster->IsPlayer())
             return originalDuration;
 
-        // if DungeonsOnly is set and we're not in a dungeon, return the original duration
-        if (!(!DungeonsOnly
-                || (target->GetMap()->IsDungeon() && caster->GetMap()->IsDungeon()) || (caster->GetMap()->IsBattleground()
-                     && target->GetMap()->IsBattleground())))
+        // make sure we're in an instance, else return the original duration
+        if (
+            !(
+                (target->GetMap()->IsDungeon() && caster->GetMap()->IsDungeon()) ||
+                (target->GetMap()->IsBattleground() && caster->GetMap()->IsBattleground())
+            )
+           )
             return originalDuration;
 
-        // if the CCDurationMultiplier isn't set on this enemy
-        if (!((float)caster->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->CCDurationMultiplier > 0))
+        // get the current creature's CC duration multiplier
+        float ccDurationMultiplier = caster->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->CCDurationMultiplier;
+
+        // if it's the default of 1.0, return the original damage
+        if (ccDurationMultiplier == 1)
             return originalDuration;
 
         // if the aura was cast by a pet or summon, return the original duration
@@ -891,7 +1024,7 @@ class AutoBalance_UnitScript : public UnitScript
             aura->HasEffectType(SPELL_AURA_MOD_SPEED_SLOW_ALL)
             )
         {
-            return originalDuration * (float)caster->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->CCDurationMultiplier;
+            return originalDuration * ccDurationMultiplier;
         }
         else
         {
@@ -911,13 +1044,16 @@ class AutoBalance_AllMapScript : public AllMapScript
 
         void OnPlayerEnterAll(Map* map, Player* player)
         {
-            if (!enabled)
+            if (!EnableGlobal)
                 return;
 
             if (player->IsGameMaster())
                 return;
 
             AutoBalanceMapInfo *mapABInfo=map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+
+            // determine if the map should be enabled for scaling based on the current settings
+            mapABInfo->enabled = ShouldMapBeEnabled(map);
 
             // always check level, even if not conf enabled
             // because we can enable at runtime and we need this information
@@ -942,7 +1078,7 @@ class AutoBalance_AllMapScript : public AllMapScript
             //mapABInfo->playerCount++; //(maybe we've to found a safe solution to avoid player recount each time)
             mapABInfo->playerCount = map->GetPlayersCountExceptGMs();
 
-            if (PlayerChangeNotify)
+            if (PlayerChangeNotify && mapABInfo->enabled)
             {
                 if (map->GetEntry()->IsDungeon() && player)
                 {
@@ -968,13 +1104,16 @@ class AutoBalance_AllMapScript : public AllMapScript
 
         void OnPlayerLeaveAll(Map* map, Player* player)
         {
-            if (!enabled)
+            if (!EnableGlobal)
                 return;
 
             if (player->IsGameMaster())
                 return;
 
             AutoBalanceMapInfo *mapABInfo=map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+
+            // determine if the map should be enabled for scaling based on the current settings
+            mapABInfo->enabled = ShouldMapBeEnabled(map);
 
             //mapABInfo->playerCount--;// (maybe we've to found a safe solution to avoid player recount each time)
             // mapABInfo->playerCount = map->GetPlayersCountExceptGMs();
@@ -1017,7 +1156,7 @@ class AutoBalance_AllMapScript : public AllMapScript
                 return;
             }
 
-            if (PlayerChangeNotify)
+            if (PlayerChangeNotify && mapABInfo->enabled)
             {
                 if (map->GetEntry()->IsDungeon() && player)
                 {
@@ -1046,28 +1185,18 @@ public:
     {
     }
 
-
     void Creature_SelectLevel(const CreatureTemplate* /*creatureTemplate*/, Creature* creature) override
     {
-        if (!enabled)
-            return;
-
         ModifyCreatureAttributes(creature, true);
     }
 
     void OnAllCreatureUpdate(Creature* creature, uint32 /*diff*/) override
     {
-        if (!enabled)
-            return;
-
         ModifyCreatureAttributes(creature);
     }
 
     void OnCreatureAddWorld(Creature* creature) override
     {
-        if (!enabled)
-            return;
-
         ModifyCreatureAttributes(creature, true);
     }
 
@@ -1078,18 +1207,30 @@ public:
 
     void ModifyCreatureAttributes(Creature* creature, bool resetSelLevel = false)
     {
+        // make sure that we're enabled globally
+        if (!EnableGlobal)
+            return;
+
+        // make sure we have a creature and that it's assigned to a map
         if (!creature || !creature->GetMap())
             return;
 
-        if (!creature->GetMap()->IsDungeon() && !creature->GetMap()->IsBattleground() && DungeonsOnly)
+        // check to make sure that the creature's map is enabled for scaling
+        AutoBalanceMapInfo *mapABInfo=creature->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+        if (!mapABInfo->enabled)
             return;
 
+        // if this isn't a dungeon or a battleground, make no changes
+        if (!(creature->GetMap()->IsDungeon() || creature->GetMap()->IsBattleground()))
+            return;
+
+        // if this is a pet or summon, make no changes
         if (((creature->IsHunterPet() || creature->IsPet() || creature->IsSummon()) && creature->IsControlledByPlayer()))
         {
             return;
         }
 
-        AutoBalanceMapInfo *mapABInfo=creature->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+        // if a map level is not set, make no changes
         if (!mapABInfo->mapLevel)
             return;
 
@@ -1159,11 +1300,10 @@ public:
         getAreaLevel(creature->GetMap(), creature->GetAreaId(), areaMinLvl, areaMaxLvl);
 
         // avoid level changing for critters and special creatures (spell summons etc.) in instances
-        bool skipLevel=false;
         if (originalLevel <= 1 && areaMinLvl >= 5)
             return;
 
-        if (LevelScaling && creature->GetMap()->IsDungeon() && !skipLevel && !checkLevelOffset(level, originalLevel)) {  // change level only whithin the offsets and when in dungeon/raid
+        if (LevelScaling && creature->GetMap()->IsDungeon() && !checkLevelOffset(level, originalLevel)) {  // change level only within the offsets and when in dungeon/raid
             if (level != creatureABInfo->selectedLevel || creatureABInfo->selectedLevel != creature->getLevel()) {
                 // keep bosses +3 level
                 creatureABInfo->selectedLevel = level + bonusLevel;
@@ -1637,7 +1777,7 @@ public:
             if (myCreatureOverrides->ccduration != -1)  { statMod_ccDuration =  myCreatureOverrides->ccduration;  }
         }
 
-        // #maththings 
+        // #maththings
         float diff = ((float)maxNumberOfPlayers/5)*1.5f;
 
         // For math reasons that I do not understand, curveCeiling needs to be adjusted to bring the actual multiplier
@@ -1663,7 +1803,7 @@ public:
         }
 
         float hpStatsRate  = 1.0f;
-        if (!useDefStats && LevelScaling && !skipLevel) {
+        if (!useDefStats && LevelScaling) {
             float newBaseHealth = 0;
             if (level <= 60)
                 newBaseHealth=creatureStats->BaseHealth[0];
@@ -1701,7 +1841,7 @@ public:
         //  Mana Scaling
         //
         float manaStatsRate  = 1.0f;
-        if (!useDefStats && LevelScaling && !skipLevel) {
+        if (!useDefStats && LevelScaling) {
             float newMana =  creatureStats->GenerateMana(creatureTemplate);
             manaStatsRate = newMana/float(baseMana);
         }
@@ -1719,7 +1859,7 @@ public:
         //  Armor Scaling
         //
         creatureABInfo->ArmorMultiplier = defaultMultiplier * statMod_global * statMod_armor;
-        uint32 newBaseArmor= round(creatureABInfo->ArmorMultiplier * (useDefStats || !LevelScaling || skipLevel ? origCreatureStats->GenerateArmor(creatureTemplate) : creatureStats->GenerateArmor(creatureTemplate)));
+        uint32 newBaseArmor= round(creatureABInfo->ArmorMultiplier * (useDefStats || !LevelScaling ? origCreatureStats->GenerateArmor(creatureTemplate) : creatureStats->GenerateArmor(creatureTemplate)));
 
         //
         //  Damage Scaling
@@ -1732,7 +1872,7 @@ public:
             damageMul = MinDamageModifier;
         }
 
-        if (!useDefStats && LevelScaling && !skipLevel) {
+        if (!useDefStats && LevelScaling) {
             float origDmgBase = origCreatureStats->GenerateBaseDamage(creatureTemplate);
             float newDmgBase = 0;
             if (level <= 60)

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -1007,10 +1007,6 @@ class AutoBalance_UnitScript : public UnitScript
         if (ccDurationMultiplier == 1)
             return originalDuration;
 
-        // if the CCDurationMultiplier isn't set on this enemy
-        if (!((float)caster->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->CCDurationMultiplier > 0))
-            return originalDuration;
-
         // if the aura was cast by a pet or summon, return the original duration
         if ((caster->IsHunterPet() || caster->IsPet() || caster->IsSummon()) && caster->IsControlledByPlayer())
             return originalDuration;


### PR DESCRIPTION
Thanks to user @alaxandir for bringing the `DungeonsOnly=0` issue to my attention.

The `AutoBalance.DungeonsOnly=0` setting appears to have never worked correctly. It was trying to balance creatures outside instance maps, which is currently outside the scope of this project. I have removed the setting and left a warning that it has been deprecated and is not processed.

I then added the  `AutoBalance.Enable.*` settings which fulfill the promise of `DungeonsOnly` by allowing the administrator to turn scaling on and off per instance type and size.

Finally, I did more code cleanup and added comments throughout the code base.

Closes #126