### PR TITLE
Fix: Crash when the caster of an aura is a player and is not online

### DIFF
--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -987,6 +987,14 @@ class AutoBalance_UnitScript : public UnitScript
         if (!EnableGlobal)
             return originalDuration;
 
+	// ensure that both the target and the caster are defined
+        if (!target || !caster)
+            return originalDuration;
+
+        // if the aura wasn't cast just now, don't change it
+        if (aura->GetDuration() != aura->GetMaxDuration())
+            return originalDuration;
+
         // if the target isn't a player or the caster is a player, return the original duration
         if (!target->IsPlayer() || caster->IsPlayer())
             return originalDuration;

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -987,7 +987,7 @@ class AutoBalance_UnitScript : public UnitScript
         if (!EnableGlobal)
             return originalDuration;
 
-	// ensure that both the target and the caster are defined
+	    // ensure that both the target and the caster are defined
         if (!target || !caster)
             return originalDuration;
 


### PR DESCRIPTION
Resolves an issue where upon logging in, auras applied to the player that were cast by a non-existent caster (like a player who is not online) causes the server to crash. Adds additional checks to ensure that the caster and target objects are valid before initiating further function calls.

Closes https://github.com/azerothcore/mod-autobalance/issues/129