### PR TITLE
Fix `AutoBalance.LevelScaling=0` bug and mapstat average bug

### DIFF
--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -987,6 +987,14 @@ class AutoBalance_UnitScript : public UnitScript
         if (!EnableGlobal)
             return originalDuration;
 
+	// ensure that both the target and the caster are defined
+        if (!target || !caster)
+            return originalDuration;
+
+        // if the aura wasn't cast just now, don't change it
+        if (aura->GetDuration() != aura->GetMaxDuration())
+            return originalDuration;
+
         // if the target isn't a player or the caster is a player, return the original duration
         if (!target->IsPlayer() || caster->IsPlayer())
             return originalDuration;

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -987,7 +987,7 @@ class AutoBalance_UnitScript : public UnitScript
         if (!EnableGlobal)
             return originalDuration;
 
-	// ensure that both the target and the caster are defined
+	    // ensure that both the target and the caster are defined
         if (!target || !caster)
             return originalDuration;
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Fixes reported issue #135 (thanks Discord user `dreathean`!) where setting `AutoBalance.LevelScaling` to 0 would cause all creatures to appear as dead (but still active and aggro'able). This was due to some incorrect `if` statements that were disabling health, mana, and damage modifier calculations for creatures when LevelScaling is disabled.
- Fixed an unreported issue where creatures that died but were then revived would count towards the average creature level calculation multiple times.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #135

## SOURCE:
- user reports
- personal testing

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- builds clean, tests well with two players (no dead creatures that should be alive)
- `.die` and `.revive` work as expected without changing the average map level calculation


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
For #135 :
1. Set `AutoBalance.LevelScaling` to `0` and enter any dungeon.

For the map stat average creature level issue:
1. Enter any instance
2. `.ab mapstat` and note the average creature level and number of active creatures
3. `.die` and `.revive` several creatures
4. `.ab mapstat` and note the average creature level and number of active creatures is still the same



