### PR TITLE
Fixed Null Ptr

### DIFF
--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -550,6 +550,17 @@ void LoadMapSettings(Map* map)
     // create an InstanceMap object
     InstanceMap* instanceMap = map->ToInstanceMap();
 
+	//check for null pointer
+	if (!map)
+	{
+		return;
+	}
+
+	if (!map->IsDungeon() && !map->IsRaid())
+	{
+		return;
+	}
+
     // should the map be enabled at all?
     mapABInfo->enabled = ShouldMapBeEnabled(map);
 


### PR DESCRIPTION
This will fix a server crash that occurs during a faction change when autobalance is present.