### PR TITLE
fix. StatModifier Per-Creature

### DIFF
--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -2620,9 +2620,9 @@ public:
 
         // Per-creature modifiers applied last
         // AutoBalance.StatModifier.PerCreature
-        if (hasStatModifierCreatureOverride(creatureTemplate->Entry))
+        if (hasStatModifierCreatureOverride(creatureABInfo->entry))
         {
-            AutoBalanceStatModifiers* myCreatureOverrides = &statModifierCreatureOverrides[creatureTemplate->Entry];
+            AutoBalanceStatModifiers* myCreatureOverrides = &statModifierCreatureOverrides[creatureABInfo->entry];
 
             if (myCreatureOverrides->global != -1)      { statMod_global =      myCreatureOverrides->global;      }
             if (myCreatureOverrides->health != -1)      { statMod_health =      myCreatureOverrides->health;      }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Allow, scale certain creatures, in different difficulties.
- Currently, it only scales to 10 normal, otherwise it ignores these values.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Configure some creature so that it does not modify its values, for example, I did the following test.
2. `AutoBalance.StatModifier.PerCreature="36855 1.0 1.0 1.0 1.0 1.0 1.0"`
3. When entering different difficulties, Lady Deathwhisper in this case, will be the only npc, which will keep its default values, without scaling.