### PR TITLE
Add per-instance disable, rework MinPlayers, enhance .ab mapstats output, improve resillience

### DIFF
--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -669,20 +669,21 @@ AutoBalance.MaxCCDurationModifier=1.0
 #
 #     AutoBalance.ForcedIDXX
 #        Sets MobIDs for the group they belong to.
-#        All 5 Man Mobs should go in .AutoBalance.5.Name
-#        All 10 Man Mobs should go in .AutoBalance.10.Name etc.
-AutoBalance.ForcedID40="11583,16441,30057,13020,15589,14435,18192,14889,14888,14887,14890,15302,15818,15742,15741,15740,18338"
-AutoBalance.ForcedID25="22997,21966,21965,21964,21806,21215,21845,19728,12397,17711,18256,18192,"
+#        All 5-player creatures should go in AutoBalance.ForcedID5=
+#        All 10-player creatures should go in AutoBalance.ForcedID10=
+#        All X-player creatures should go in AutoBalance.ForcedIDX=
+AutoBalance.ForcedID40=""
+AutoBalance.ForcedID25=""
 AutoBalance.ForcedID20=""
-AutoBalance.ForcedID10="15689,15550,16152,17521,17225,16028,29324,31099"
-AutoBalance.ForcedID5="8317,15203,15204,15205,15305,6109,26801,30508,26799,30495,26803,30497,27859,27249"
+AutoBalance.ForcedID10=""
+AutoBalance.ForcedID5=""
 AutoBalance.ForcedID2=""
 
 #
 #     AutoBalance.DisabledID
 #        Disable scaling on specific creatures
 #
-AutoBalance.DisabledID="6867"
+AutoBalance.DisabledID=""
 
 ##########################
 #

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -1,7 +1,7 @@
 [worldserver]
 ##########################
 #
-# Enable Settings
+# Enable / Disable Settings
 #
 ##########################
 
@@ -29,6 +29,67 @@ AutoBalance.Enable.5MHeroic=1
 AutoBalance.Enable.10MHeroic=1
 AutoBalance.Enable.25MHeroic=1
 AutoBalance.Enable.OtherHeroic=1
+
+#
+#     AutoBalance.Disable.PerInstance
+#        Disable all features for the given instance IDs. If an instance ID is not specified here, that instance will follow
+#        the `AutoBalance.Enable.*` settings.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID], [InstanceID], [InstanceID], ..."
+#
+#        Example: AutoBalance.Disable.PerInstance="33, 43, 129"
+#
+#        Default: ""
+AutoBalance.Disable.PerInstance = ""
+
+##########################
+#
+# Minimum Players
+#
+##########################
+#
+#     AutoBalance.MinPlayers
+#     AutoBalance.MinPlayers.Heroic
+#        Sets the Minimum Number of players to scale down to for all normal/heroic instances.
+#        If fewer than this number of players enter the instance, scale to the specified value.
+#
+#        NOTE: Player Difficulty Offset is applied AFTER the player count is adjusted for the MinPlayer setting
+#
+#        AutoBalance.MinPlayers affects only normal instances.
+#        AutoBalance.MinPlayers.Heroic affects only heroic instances.
+#
+#        Example: AutoBalance.MinPlayers = 1
+#                 AutoBalance.MinPlayers.Heroic = 5
+#
+#        Default: 1
+AutoBalance.MinPlayers = 1
+AutoBalance.MinPlayers.Heroic = 1
+
+#
+#     AutoBalance.MinPlayers.PerInstance
+#     AutoBalance.MinPlayers.Heroic.PerInstance
+#        Sets the Minimum Number of players to scale down to per-instance ID.
+#        If fewer than this number of players enter the instance, scale to the specified value.
+#
+#        NOTE: Player Difficulty Offset is applied AFTER the player count is adjusted for the MinPlayer setting
+#
+#        AutoBalance.MinPlayers.PerInstance affects only normal instances.
+#        AutoBalance.MinPlayers.Heroic.PerInstance affects only heroic instances.
+#
+#        If a given Instance ID is not specified in this list, the minimum number of players is set by the generic MinPlayers settings.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [MinPlayers], [InstanceID] [MinPlayers], [InstanceID] [MinPlayers], ..."
+#
+#        Example: AutoBalance.MinPlayers.PerInstance="33 2, 43 5, 129 4"
+#                 AutoBalance.MinPlayers.PerInstance="33 5, 43 5, 129 5"
+#
+#        Default: ""
+AutoBalance.MinPlayers.PerInstance = ""
+AutoBalance.MinPlayers.Heroic.PerInstance = ""
 
 ##########################
 #
@@ -604,16 +665,6 @@ AutoBalance.MaxCCDurationModifier=1.0
 # Misc Settings
 #
 ##########################
-#
-#     AutoBalance.PerDungeonPlayerCounts
-#        Allows setting a per-instance setting for minimum number of players to scale. For example, dungeons could remain at 5 players, but raids could be chosen to scale down to 5 players as well.
-#        Formatted as "[InstanceID] [playerCount], [InstanceID] [playerCount], [InstanceID] [playerCount], ..."
-#        Example: AutoBalance.PerDungeonPlayerCounts="33 1,34 1,36 1,43 1,47 1,48 1,70 1,90 1,109 1,129 1,189 1,209 1,349 1,389 1, 289 2, 329 2, 230 2, 429 2, 309 5, 409 5"
-#        For instances not listed, the instance's original player count (5, 10, 20, 25, or 40) is used as the minimum, meaning no scaling will take place.
-#        To disable, leave empty; all instances will then scale down to 1 player minimum. This is the default setting.
-#        Default: ""
-#
-AutoBalance.PerDungeonPlayerCounts=""
 
 #
 #     AutoBalance.ForcedIDXX
@@ -914,6 +965,7 @@ AutoBalance.DungeonScaleDownXP=
 AutoBalance.DungeonScaleDownMoney=
 AutoBalance.LevelHigherOffset=
 AutoBalance.LevelLowerOffset=
+AutoBalance.PerDungeonPlayerCounts=
 
 # The following variables have been removed entirely and should not be used in a new or existing deployment.
 # Their values should be left blank.

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -468,7 +468,7 @@ bool isDungeonInDisabledDungeonIds(uint32 dungeonId)
 
 bool isDungeonInMinPlayerMap(uint32 dungeonId, bool isHeroic)
 {
-    if (isHeroic == true) {
+    if (isHeroic) {
         return (minPlayersPerHeroicDungeonIdMap.find(dungeonId) != minPlayersPerHeroicDungeonIdMap.end());
     } else {
         return (minPlayersPerDungeonIdMap.find(dungeonId) != minPlayersPerDungeonIdMap.end());

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -3128,7 +3128,12 @@ public:
         if (player->GetMap()->IsDungeon() || player->GetMap()->IsBattleground())
         {
             handler->PSendSysMessage("---");
-            handler->PSendSysMessage("Map: %s (ID: %u)%s", player->GetMap()->GetMapName(), player->GetMapId(), mapABInfo->enabled ? "" : " - AutoBalance is DISABLED");
+            handler->PSendSysMessage("Map: ID %u | %s (%u-player %s)",
+                                    player->GetMapId(),
+                                    player->GetMap()->GetMapName(),
+                                    player->GetMap()->ToInstanceMap()->GetMaxPlayers(),
+                                    player->GetMap()->ToInstanceMap()->IsHeroic() ? "Heroic" : "Normal",
+                                    mapABInfo->enabled ? "" : " | AutoBalance DISABLED");
             handler->PSendSysMessage("Players on map: %u (Lvl %u - %u)",
                                     mapABInfo->playerCount,
                                     mapABInfo->lowestPlayerLevel,


### PR DESCRIPTION
Thought you got rid of me?

I've focused some time on improving the "top of the config" settings in this PR. For your consideration:

Major Features:
- Added the ability to disable specific instance IDs (`AutoBalance.Disable.PerInstance`)
- Deprecated `AutoBalance.PerDungeonPlayerCounts` in favor of the `AutoBalance.MinPlayers.*` series, which allows setting much more granular MinPlayer settings

**AutoBalance.Disable.***
Specific InstanceIDs can be disabled now using `AutoBalance.Disable.PerInstance`. I also reworked the logic behind the other `AutoBalance.Disable.*` settings to store the disabled state per-map-instance, meaning it only has to be calculated once. 

A config reload will re-evaluate if a map-instance needs to be enabled/disabled, and will adjust the creatures accordingly. No need to restart the server if you change these settings anymore.

**AutoBalance.MinPlayers.**
This series of settings replaces `AutoBalance.PerDungeonPlayerCounts`, which is now deprecated. If `AutoBalance.PerDungeonPlayerCounts` is still in use, the mod will attempt to map its settings onto the new feature, but the functionality will not be exactly 1:1.

The biggest change is that using the `AutoBalance.MinPlayers.*` settings will not disable number-of-players scaling for all other instances like the old setting did. In fact, you can now specify your own "default" MinPlayers settting using `AutoBalance.MinPlayers` and `AutoBalance.MinPlayers.Heroic`.

If more granular control is desired, you can override specific InstanceIDs (for either normal OR heroic) using `AutoBalance.MinPlayers.PerInstance` and `AutoBalance.MinPlayers.Heroic.PerInstance`.

The net effect of the MinPlayers setting is that if there are fewer players than MinPlayers in an instance, scaling will treat the instance as though there were MinPlayers in it. This value cannot exceed the max number of players for the instance (handled gracefully if you specify something higher). Do note that the Player Difficulty Offset is applied AFTER this, so you can still adjust global difficulty using that feature.

** Other Changes **
- updates to several player-facing messages to better convey information about the number of players and the difficulty setting the instance is set to
- updates to `.ab mapstat` to give more information about how AB is making its scaling decisions
- extra DEBUG logging for tracking down issues
- better overall resilience during a config reload to allow config changes to be made on-the-fly without restarting the server
- removed several very-old defaults regarding forced scaling for certain creature IDs. As far as I can tell these are not needed anymore.

I look forward to your testing and review! Once we get this one done, I am planning on working on world damage (so not sourced from creatures) next, which should fix several reported issues related to un-scaled damage mechanics.

- Closes #69 
- Closes #68 