### PR TITLE
World damage/healing, destructible buildings, multiplier rewrite, logging improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,6 +44,16 @@ body:
     validations:
       required: false
   - type: textarea
+    id: abcommands
+    attributes:
+      label: AutoBalance Debug Commands
+      description: |
+        Please include text or an image of the `.ab mapstat` command. If your issue is concerning scaling of creatures, please also include the `.ab creaturestat` command while targeting the problematic creature.
+      placeholder: |
+        None
+    validations:
+      required: false
+  - type: textarea
     id: commit
     attributes:
       label: AC rev. hash/commit

--- a/README.md
+++ b/README.md
@@ -1,10 +1,33 @@
 # ![logo](https://raw.githubusercontent.com/azerothcore/azerothcore.github.io/master/images/logo-github.png) AzerothCore
-## AutoBalanceModule
+
+## AutoBalance
+
 - Latest build status with azerothcore: [![Build Status](https://github.com/azerothcore/mod-autobalance/workflows/core-build/badge.svg?branch=master&event=push)](https://github.com/azerothcore/mod-autobalance)
 
 This module is intended to scale based on number of players, instance mobs and bosses' health, mana, and damage.
 
+**NOTE:** This module requires at least [this commit](https://github.com/azerothcore/azerothcore-wotlk/commit/f127e583aae3cfa51a77d056c1892a7de07ffb52) of AzerothCore in order to work correctly. Older versions are not supported.
+
 All settings are well-described in the configuration file.
+
+**PLEASE** include the output from the `.ab mapstat` and `.ab creaturestat` commands (while targeting a problematic creature) when reporting issues. This will help us to quickly identify the problem and provide a solution.
+
+## In-game Commands
+| Command | Permission | Description |
+| :------ | :--------- | :---------- |
+| `.ab mapstat` | All Players | Displays AB-calcualted settings for the current map, including player count, difficulty, world modifiers, and others. |
+| `.ab creaturestat` | All Players | Displays AB-calculated settings for the targeted dungeon creature including level scaling, difficulty, modifiers, and boss status. |
+| `.ab setoffset` | Game Masters | Sets the server-wide player difficulty offset. Instances will be scaled as though they had this many more/less players than they really do. |
+| `.ab getoffset` | All Players | Gets the current server-wide player difficulty offset. Instances will be scaled as though they had this many more/less players than they really do. |
+| `.reload config` | Game Masters | Reloads all your configuration files, including `AutoBalance.conf`. This lets you update AutoBalance settings without restarting your worldserver. This module is designed to contiue to work as expected when this command is issued. |
+
+## Logger Names
+| Logger | Description |
+| :----- | ----------- |
+| `Logger.module.AutoBalance` | Main logger, verbose debug logs. Map detection, list management, creature adjustments, multiplier, modifiers. Catch-all. |
+| `Logger.module.AutoBalance_CombatLocking` | Debug logs related to the combat locking/unlocking mechanism for maps. |
+| `Logger.module.AutoBalance_DamageHealingCC` | Debug logs for the spell/melee/CC modifications that are made in real-time. |
+| `Logger.module.AutoBalance_StatGeneration` | Detailed debug logs that show all the calculation steps in how different multipliers are derived. |
 
 ## References
 - [Interactive Inflection Point Spreadsheet](https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy)

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -1,6 +1,17 @@
 [worldserver]
 ##########################
 #
+# Logging
+# 4 = Info, 5 = Debug
+#
+##########################
+Logger.module.AutoBalance=4,Console Server
+Logger.module.AutoBalance_CombatLocking=4,Console Server
+Logger.module.AutoBalance_DamageHealingCC=4,Console Server
+Logger.module.AutoBalance_StatGeneration=4,Console Server
+
+##########################
+#
 # Enable / Disable Settings
 #
 ##########################

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -300,6 +300,8 @@ AutoBalance.playerCountDifficultyOffset=0
 #        Health | Mana | Armor | Damage
 #           Adjusts the StatModifier for the appropriate stat. Affected by the Global StatModifier above.
 #
+#           NOTE: "Damage" affects both creature damage and world damage.
+#
 #           Default: 1.0
 #
 #        Boss.Global | Boss.Health | Boss.Mana | Boss.Armor | Boss.Damage
@@ -812,7 +814,7 @@ AutoBalance.LevelScaling.DynamicLevel.DistanceCheck.PerInstance="189 500"
 #        to have stats as near possible to the official ones.
 #
 #        Default:     1 (1 = ON, 0 = OFF)
-AutoBalance.LevelScaling.EndGameBoost = 1
+AutoBalance.LevelScaling.EndGameBoost = 0
 
 ##########################
 #

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -809,12 +809,19 @@ AutoBalance.LevelScaling.DynamicLevel.DistanceCheck.PerInstance="189 500"
 
 #
 #     AutoBalance.LevelScaling.LevelEndGameBoost
+#
+#        NOTICE: This setting is currently not implemented pending a rewrite.
+#                Enabling it here has NO effect.
+#
+#        See: https://github.com/azerothcore/mod-autobalance/issues/156
+#
+#        Old description:
 #        End game creatures have an exponential (not linear) regression
 #        that is not correctly handled by db values. Keep this enabled
 #        to have stats as near possible to the official ones.
 #
-#        Default:     1 (1 = ON, 0 = OFF)
-AutoBalance.LevelScaling.EndGameBoost = 0
+#        Default:     0 (1 = ON, 0 = OFF)
+AutoBalance.LevelScaling.EndGameBoost = 0        # setting to 1 does not do anything
 
 ##########################
 #

--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -2,13 +2,16 @@
 ##########################
 #
 # Logging
-# 4 = Info, 5 = Debug
+#
+# Add these lines to your worldserver.conf file to enable logging for AutoBalance.
+#
+# 4 = Info (Default), 5 = Debug
 #
 ##########################
-Logger.module.AutoBalance=4,Console Server
-Logger.module.AutoBalance_CombatLocking=4,Console Server
-Logger.module.AutoBalance_DamageHealingCC=4,Console Server
-Logger.module.AutoBalance_StatGeneration=4,Console Server
+# Logger.module.AutoBalance=4,Console Server
+# Logger.module.AutoBalance_CombatLocking=4,Console Server
+# Logger.module.AutoBalance_DamageHealingCC=4,Console Server
+# Logger.module.AutoBalance_StatGeneration=4,Console Server
 
 ##########################
 #

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -4072,7 +4072,12 @@ class AutoBalance_UnitScript : public UnitScript
 
             // we are good to go, return the original damage times the multiplier
             if (_debug_damage_and_healing)
-                LOG_DEBUG("module.AutoBalance_DamageHealingCC", "AutoBalance_UnitScript::_Modify_Damage_Healing: Returning modified damage: ({}) * ({}) = ({})", amount, damageMultiplier, amount * damageMultiplier);
+                LOG_DEBUG("module.AutoBalance_DamageHealingCC", "AutoBalance_UnitScript::_Modify_Damage_Healing: Returning modified {}: ({}) * ({}) = ({})",
+                    amount <= 0 ? "damage" : "healing",
+                    amount,
+                    damageMultiplier,
+                    amount * damageMultiplier
+                );
 
             return amount * damageMultiplier;
         }
@@ -5073,7 +5078,12 @@ public:
 
             // handle "special" creatures
             // note that these already passed a more complex check above
-            if (creature->IsTotem() || (creature->IsCritter() && creatureABInfo->UnmodifiedLevel <= 5 && creature->GetMaxHealth() <= 100))
+            if (
+                (creature->IsTotem() && creature->IsSummon() && creature->ToTempSummon() && creature->ToTempSummon()->GetSummoner() && creature->ToTempSummon()->GetSummoner()->IsPlayer()) ||
+                (
+                    creature->IsCritter() && creatureABInfo->UnmodifiedLevel <= 5 && creature->GetMaxHealth() <= 100
+                )
+            )
             {
                 LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::ModifyCreatureAttributes: Creature {} ({}) | is a {} that will not be level scaled, but will have modifiers set.",
                             creature->GetName(),

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -2494,7 +2494,7 @@ void RemoveCreatureFromMapData(Creature* creature)
                     }
                     else
                     {
-                        LOG_WARN("module.AutoBalance", "AutoBalance::RemoveCreatureFromMapData: Map {} ({}{}) | activeCreatureCount is already 0. This should not happen.",
+                        LOG_DEBUG("module.AutoBalance", "AutoBalance::RemoveCreatureFromMapData: Map {} ({}{}) | activeCreatureCount is already 0. This should not happen.",
                             creature->GetMap()->GetMapName(),
                             creature->GetMap()->GetId(),
                             creature->GetMap()->GetInstanceId() ? "-" + std::to_string(creature->GetMap()->GetInstanceId()) : ""

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -3565,7 +3565,7 @@ class AutoBalance_PlayerScript : public PlayerScript
                 return;
             }
 
-            LOG_DEBUG("module.AutoBalance_CombatLocking", "AutoBalance_PlayerScript::OnPlayerEnterCombat: {}", player->GetName());
+            LOG_DEBUG("module.AutoBalance_CombatLocking", "AutoBalance_PlayerScript::OnPlayerEnterCombat: {} enters combat.", player->GetName());
 
             AutoBalanceMapInfo *mapABInfo = map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
 
@@ -3599,7 +3599,7 @@ class AutoBalance_PlayerScript : public PlayerScript
                 return;
             }
 
-            LOG_DEBUG("module.AutoBalance_CombatLocking", "AutoBalance_PlayerScript::OnPlayerLeaveCombat: {}", player->GetName());
+            LOG_DEBUG("module.AutoBalance_CombatLocking", "AutoBalance_PlayerScript::OnPlayerLeaveCombat: {} leaves combat.", player->GetName());
 
             AutoBalanceMapInfo *mapABInfo=map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
 

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -261,7 +261,7 @@ public:
     int floor;
 };
 
-uint64_t GetCurrentTime()
+uint64_t GetCurrentConfigTime()
 {
     return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
@@ -331,7 +331,7 @@ static bool RewardScalingXP, RewardScalingMoney;
 static float RewardScalingXPModifier, RewardScalingMoneyModifier;
 
 // Track the initial config time
-static uint64_t globalConfigTime = GetCurrentTime();
+static uint64_t globalConfigTime = GetCurrentConfigTime();
 
 // Enable.*
 static bool EnableGlobal;
@@ -1319,7 +1319,11 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
     {
         switch (maxNumberOfPlayers)
         {
-            case 1 ... 5:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
                 if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierHeroic_Boss_Global;
@@ -1343,7 +1347,11 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                     getStatModifiersDebug(map, creature, "1 to 5 Player Heroic");
                 }
                 break;
-            case 6 ... 10:
+            case 6:
+            case 7:
+            case 8:
+            case 9:
+            case 10:
                 if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid10MHeroic_Boss_Global;
@@ -1367,7 +1375,21 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                     getStatModifiersDebug(map, creature, "10 Player Heroic");
                 }
                 break;
-            case 11 ... 25:
+            case 11:
+            case 12:
+            case 13:
+            case 14:
+            case 15:
+            case 16:
+            case 17:
+            case 18:
+            case 19:
+            case 20:
+            case 21:
+            case 22:
+            case 23:
+            case 24:
+            case 25:
                 if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid25MHeroic_Boss_Global;
@@ -1418,9 +1440,14 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
     }
     else // non-heroic
     {
+        // unfortunately, the Windows C++ compiler doesn't support switch statements with ranges so we're forced to list all the values
         switch (maxNumberOfPlayers)
         {
-            case 1 ... 5:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
                 if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifier_Boss_Global;
@@ -1444,7 +1471,11 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                     getStatModifiersDebug(map, creature, "1 to 5 Player Normal");
                 }
                 break;
-            case 6 ... 10:
+            case 6:
+            case 7:
+            case 8:
+            case 9:
+            case 10:
                 if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid10M_Boss_Global;
@@ -1468,7 +1499,11 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                     getStatModifiersDebug(map, creature, "10 Player Normal");
                 }
                 break;
-            case 11 ... 15:
+            case 11:
+            case 12:
+            case 13:
+            case 14:
+            case 15:
                 if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid15M_Boss_Global;
@@ -1492,7 +1527,11 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                     getStatModifiersDebug(map, creature, "15 Player Normal");
                 }
                 break;
-            case 16 ... 20:
+            case 16:
+            case 17:
+            case 18:
+            case 19:
+            case 20:
                 if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid20M_Boss_Global;
@@ -1516,7 +1555,11 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                     getStatModifiersDebug(map, creature, "20 Player Normal");
                 }
                 break;
-            case 21 ... 25:
+            case 21:
+            case 22:
+            case 23:
+            case 24:
+            case 25:
                 if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid25M_Boss_Global;
@@ -1540,7 +1583,21 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                     getStatModifiersDebug(map, creature, "25 Player Normal");
                 }
                 break;
-            case 26 ... 40:
+            case 26:
+            case 27:
+            case 28:
+            case 29:
+            case 30:
+            case 31:
+            case 32:
+            case 33:
+            case 34:
+            case 35:
+            case 36:
+            case 37:
+            case 38:
+            case 39:
+            case 40:
                 if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid40M_Boss_Global;
@@ -2932,7 +2989,7 @@ bool UpdateMapDataIfNeeded(Map* map, bool force = false)
 
         // mark the config updated
         mapABInfo->globalConfigTime = globalConfigTime;
-        mapABInfo->mapConfigTime = GetCurrentTime();
+        mapABInfo->mapConfigTime = GetCurrentConfigTime();
 
         LOG_DEBUG("module.AutoBalance", "AutoBalance::UpdateMapDataIfNeeded: {} ({}{}) | Global config time set to ({}).",
                     map->GetMapName(),
@@ -3000,7 +3057,7 @@ class AutoBalance_WorldScript : public WorldScript
     void OnBeforeConfigLoad(bool /*reload*/) override
     {
         SetInitialWorldSettings();
-        globalConfigTime = GetCurrentTime();
+        globalConfigTime = GetCurrentConfigTime();
 
         LOG_INFO("module.AutoBalance", "AutoBalance::OnBeforeConfigLoad: Config loaded. Global config time set to ({}).", globalConfigTime);
     }
@@ -3466,7 +3523,7 @@ class AutoBalance_PlayerScript : public PlayerScript
 
             // schedule all creatures for an update
             AutoBalanceMapInfo *mapABInfo=map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
-            mapABInfo->mapConfigTime = GetCurrentTime();
+            mapABInfo->mapConfigTime = GetCurrentConfigTime();
         }
 
         void OnGiveXP(Player* player, uint32& amount, Unit* victim, uint8 /*xpSource*/) override
@@ -5918,7 +5975,7 @@ public:
             offseti = (uint32)atoi(offset);
             handler->PSendSysMessage("Changing Player Difficulty Offset to %i.", offseti);
             PlayerCountDifficultyOffset = offseti;
-            globalConfigTime = GetCurrentTime();
+            globalConfigTime = GetCurrentConfigTime();
             return true;
         }
         else

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -300,7 +300,7 @@ static std::list<uint32> spellIdsThatSpendPlayerHealth =
 
 static std::list<uint32> spellIdsToNeverModify = 
 {
-    1177        // Twin Empathy (AQ40 Twin Emperors)
+    1177,       // Twin Empathy (AQ40 Twin Emperors, only in `spell_dbc`)
 };
 
 // spacer used for logging

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -146,8 +146,6 @@ public:
     uint32 instancePlayerCount = 0;                 // the number of players this creature has been scaled for
     uint8 selectedLevel = 0;                        // the level that this creature should be set to
 
-    uint32 entry = 0;                               // TODO: see if this is still needed. Creature entry ID
-
     float DamageMultiplier = 1.0f;                  // per-player damage multiplier (no level scaling)
     float ScaledDamageMultiplier = 1.0f;            // per-player and level scaling damage multiplier
 
@@ -165,7 +163,7 @@ public:
     float XPModifier = 1.0f;                        // per-player XP modifier (level scaling provided by normal XP distribution)
     float MoneyModifier = 1.0f;                     // per-player money modifier (no level scaling)
 
-    uint8 UnmodifiedLevel = 0;                      // original the level of the creature as determined by the game
+    uint8 UnmodifiedLevel = 0;                      // original level of the creature as determined by the game
 
     bool isActive = false;                          // whether or not the current creature is affecting map stats. May change as conditions change.
     bool wasAliveNowDead = false;                   // whether or not the creature was alive and is now dead
@@ -181,45 +179,45 @@ class AutoBalanceMapInfo : public DataMap::Base
 public:
     AutoBalanceMapInfo() {}
 
-    uint64_t globalConfigTime = 1;                  // the last global config time that this map was updated
-    uint64_t mapConfigTime = 1;                     // the last map config time that this map was updated
+    uint64_t globalConfigTime = 1;                   // the last global config time that this map was updated
+    uint64_t mapConfigTime = 1;                      // the last map config time that this map was updated
 
-    uint8 playerCount = 0;                         // the base number of players, normally based on the actual number of players
-    uint8 adjustedPlayerCount = 0;                 // the number of players for the purposes of scaling
-    uint8 minPlayers = 1;                          // will bet set by the config
+    uint8 playerCount = 0;                           // the actual number of non-GM players in the map
+    uint8 adjustedPlayerCount = 0;                   // the currently difficulty level expressed as number of players
+    uint8 minPlayers = 1;                            // will be set by the config
 
-    uint8 mapLevel = 0;                             // calculated from the avgCreatureLevel
-    uint8 lowestPlayerLevel = 0;                    // the lowest-level player in the map
-    uint8 highestPlayerLevel = 0;                   // the highest-level player in the map
+    uint8 mapLevel = 0;                              // calculated from the avgCreatureLevel
+    uint8 lowestPlayerLevel = 0;                     // the lowest-level player in the map
+    uint8 highestPlayerLevel = 0;                    // the highest-level player in the map
 
-    uint8 lfgMinLevel = 0;                          // the minimum level for the map according to LFG
-    uint8 lfgTargetLevel = 0;                       // the target level for the map according to LFG
-    uint8 lfgMaxLevel = 0;                          // the maximum level for the map according to LFG
+    uint8 lfgMinLevel = 0;                           // the minimum level for the map according to LFG
+    uint8 lfgTargetLevel = 0;                        // the target level for the map according to LFG
+    uint8 lfgMaxLevel = 0;                           // the maximum level for the map according to LFG
 
-    uint8 worldMultiplierTargetLevel = 0;           // the level of the pseudo-creature that the world modifiers scale to
-    float worldDamageHealingMultiplier = 1.0f;      // the damage/healing multiplier for the world (damage/healing not from a creature)
-    float scaledWorldDamageHealingMultiplier = 1.0f;// the damage/healing multiplier for the world (damage/healing not from a creature) with level scaling
-    float worldHealthMultiplier = 1.0f;             // the health multiplier for any destructible buildings in the map
+    uint8 worldMultiplierTargetLevel = 0;            // the level of the pseudo-creature that the world modifiers scale to
+    float worldDamageHealingMultiplier = 1.0f;       // the damage/healing multiplier for the world (where source isn't an enemy creature)
+    float scaledWorldDamageHealingMultiplier = 1.0f; // the damage/healing multiplier for the world (where source isn't an enemy creature)
+    float worldHealthMultiplier = 1.0f;              // the "health" multiplier for any destructible buildings in the map
 
-    bool enabled = false;                           // should AutoBalance make any changes to this map or its creatures?
+    bool enabled = false;                            // should AutoBalance make any changes to this map or its creatures?
 
-    std::vector<Creature*> allMapCreatures;         // all creatures in the map, active and non-active
-    std::vector<Player*> allMapPlayers;             // all players that are currently in the map
+    std::vector<Creature*> allMapCreatures;          // all creatures in the map, active and non-active
+    std::vector<Player*> allMapPlayers;              // all players that are currently in the map
 
-    bool combatLocked = false;                      // whether or not the map is combat locked
-    bool combatLockTripped = false;                 // set to true when combat locking was needed during this current combat
-    uint8 combatLockMinPlayers = 0;                 // the instance cannot be set to less than this number of players until combat ends
+    bool combatLocked = false;                       // whether or not the map is combat locked
+    bool combatLockTripped = false;                  // set to true when combat locking was needed during this current combat (some tried to leave)
+    uint8 combatLockMinPlayers = 0;                  // the instance cannot be set to less than this number of players until combat ends
 
-    uint8 highestCreatureLevel = 0;                 // the highest-level creature in the map
-    uint8 lowestCreatureLevel = 0;                  // the lowest-level creature in the map
-    float avgCreatureLevel = 0;                     // the average level of all active creatures in the map (continuously updated)
-    uint32 activeCreatureCount = 0;                 // the number of active creatures in the map (not necessarily alive)
+    uint8 highestCreatureLevel = 0;                  // the highest-level creature in the map
+    uint8 lowestCreatureLevel = 0;                   // the lowest-level creature in the map
+    float avgCreatureLevel = 0;                      // the average level of all active creatures in the map (continuously updated)
+    uint32 activeCreatureCount = 0;                  // the number of creatures in the map that are included in the map's stats (not necessarily alive)
 
-    bool isLevelScalingEnabled = false;             // whether level scaling is enabled on this map
-    uint8 levelScalingSkipHigherLevels;             // used to determine if this map should scale or not
-    uint8 levelScalingSkipLowerLevels;              // used to determine if this map should scale or not
-    uint8 levelScalingDynamicCeiling;               // how many levels MORE than the highestPlayerLevel creature should be scaled to
-    uint8 levelScalingDynamicFloor;                 // how many levels LESS than the highestPlayerLevel creature should be scaled to
+    bool isLevelScalingEnabled = false;              // whether level scaling is enabled on this map
+    uint8 levelScalingSkipHigherLevels;              // used to determine if this map should scale or not
+    uint8 levelScalingSkipLowerLevels;               // used to determine if this map should scale or not
+    uint8 levelScalingDynamicCeiling;                // how many levels MORE than the highestPlayerLevel creature should be scaled to
+    uint8 levelScalingDynamicFloor;                  // how many levels LESS than the highestPlayerLevel creature should be scaled to
 
     uint8 prevMapLevel = 0;                          // used to reduce calculations when they are not necessary
 };
@@ -671,55 +669,61 @@ bool ShouldMapBeEnabled(Map* map)
         {
             //LOG_DEBUG("module.AutoBalance", "AutoBalance::ShouldMapBeEnabled: Heroic Enables - 5:{} 10:{} 25:{} Other:{}",
             //            Enable5MHeroic, Enable10MHeroic, Enable25MHeroic, EnableOtherHeroic);
-            switch (instanceMap->GetMaxPlayers())
+
+            if (instanceMap->GetMaxPlayers() <= 5)
             {
-                case 5:
-                    sizeDifficultyEnabled = Enable5MHeroic;
-                    break;
-                case 10:
-                    sizeDifficultyEnabled = Enable10MHeroic;
-                    break;
-                case 25:
-                    sizeDifficultyEnabled = Enable25MHeroic;
-                    break;
-                default:
-                    sizeDifficultyEnabled = EnableOtherHeroic;
-                    break;
+                sizeDifficultyEnabled = Enable5MHeroic;
+            }
+            else if (instanceMap->GetMaxPlayers() <= 10)
+            {
+                sizeDifficultyEnabled = Enable10MHeroic;
+            }
+            else if (instanceMap->GetMaxPlayers() <= 25)
+            {
+                sizeDifficultyEnabled = Enable25MHeroic;
+            }
+            else
+            {
+                sizeDifficultyEnabled = EnableOtherHeroic;
             }
         }
         else
         {
             //LOG_DEBUG("module.AutoBalance", "AutoBalance::ShouldMapBeEnabled: Normal Enables - 5:{} 10:{} 15:{} 20:{} 25:{} 40:{} Other:{}",
             //            Enable5M, Enable10M, Enable15M, Enable20M, Enable25M, Enable40M, EnableOtherNormal);
-            switch (instanceMap->GetMaxPlayers())
+            if (instanceMap->GetMaxPlayers() <= 5)
             {
-                case 5:
-                    sizeDifficultyEnabled = Enable5M;
-                    break;
-                case 10:
-                    sizeDifficultyEnabled = Enable10M;
-                    break;
-                case 15:
-                    sizeDifficultyEnabled = Enable15M;
-                    break;
-                case 20:
-                    sizeDifficultyEnabled = Enable20M;
-                    break;
-                case 25:
-                    sizeDifficultyEnabled = Enable25M;
-                    break;
-                case 40:
-                    sizeDifficultyEnabled = Enable40M;
-                    break;
-                default:
-                    sizeDifficultyEnabled = EnableOtherNormal;
-                    break;
+                sizeDifficultyEnabled = Enable5M;
+            }
+            else if (instanceMap->GetMaxPlayers() <= 10)
+            {
+                sizeDifficultyEnabled = Enable10M;
+            }
+            else if (instanceMap->GetMaxPlayers() <= 15)
+            {
+                sizeDifficultyEnabled = Enable15M;
+            }
+            else if (instanceMap->GetMaxPlayers() <= 20)
+            {
+                sizeDifficultyEnabled = Enable20M;
+            }
+            else if (instanceMap->GetMaxPlayers() <= 25)
+            {
+                sizeDifficultyEnabled = Enable25M;
+            }
+            else if (instanceMap->GetMaxPlayers() <= 40)
+            {
+                sizeDifficultyEnabled = Enable40M;
+            }
+            else
+            {
+                sizeDifficultyEnabled = EnableOtherNormal;
             }
         }
 
         if (sizeDifficultyEnabled)
         {
-            LOG_DEBUG("module.AutoBalance", "AutoBalance::ShouldMapBeEnabled: Map {} ({}{}, {}-player {}) - Enabled for AutoBalancing.",
+            LOG_DEBUG("module.AutoBalance", "AutoBalance::ShouldMapBeEnabled: Map {} ({}{}, {}-player {}) | Enabled for AutoBalancing.",
                       map->GetMapName(),
                       map->GetId(),
                       map->GetInstanceId() ? "-" + std::to_string(map->GetInstanceId()) : "",
@@ -729,7 +733,7 @@ bool ShouldMapBeEnabled(Map* map)
         }
         else
         {
-            LOG_DEBUG("module.AutoBalance", "AutoBalance::ShouldMapBeEnabled: Map {} ({}{}, {}-player {}) - Not enabled because its size and difficulty are disabled via configuration.",
+            LOG_DEBUG("module.AutoBalance", "AutoBalance::ShouldMapBeEnabled: Map {} ({}{}, {}-player {}) | Not enabled because its size and difficulty are disabled via configuration.",
                       map->GetMapName(),
                       map->GetId(),
                       map->GetInstanceId() ? "-" + std::to_string(map->GetInstanceId()) : "",
@@ -742,7 +746,7 @@ bool ShouldMapBeEnabled(Map* map)
     }
     else
     {
-        LOG_DEBUG("module.AutoBalance", "AutoBalance::ShouldMapBeEnabled: Map {} ({}{}) - Not enabled because the map is not an instance.",
+        LOG_DEBUG("module.AutoBalance", "AutoBalance::ShouldMapBeEnabled: Map {} ({}{}) | Not enabled because the map is not an instance.",
                     map->GetMapName(),
                     map->GetId(),
                     map->GetInstanceId() ? "-" + std::to_string(map->GetInstanceId()) : ""
@@ -1053,7 +1057,7 @@ bool isCreatureRelevant(Creature* creature) {
 
     }
 
-    // if this is a critter
+    // if this is a flavor critter
     // level and health checks for some nasty level 1 critters in some encounters
     if ((creature->IsCritter() && creatureABInfo->UnmodifiedLevel <= 5 && creature->GetMaxHealth() < 100))
     {
@@ -1090,75 +1094,74 @@ AutoBalanceInflectionPointSettings getInflectionPointSettings (InstanceMap* inst
     //
     if (instanceMap->IsHeroic())
     {
-        switch (maxNumberOfPlayers)
+        if (maxNumberOfPlayers <= 5)
         {
-            case 1:
-            case 2:
-            case 3:
-            case 4:
-            case 5:
-                inflectionValue *= InflectionPointHeroic;
-                curveFloor = InflectionPointHeroicCurveFloor;
-                curveCeiling = InflectionPointHeroicCurveCeiling;
-                break;
-            case 10:
-                inflectionValue *= InflectionPointRaid10MHeroic;
-                curveFloor = InflectionPointRaid10MHeroicCurveFloor;
-                curveCeiling = InflectionPointRaid10MHeroicCurveCeiling;
-                break;
-            case 25:
-                inflectionValue *= InflectionPointRaid25MHeroic;
-                curveFloor = InflectionPointRaid25MHeroicCurveFloor;
-                curveCeiling = InflectionPointRaid25MHeroicCurveCeiling;
-                break;
-            default:
-                inflectionValue *= InflectionPointRaidHeroic;
-                curveFloor = InflectionPointRaidHeroicCurveFloor;
-                curveCeiling = InflectionPointRaidHeroicCurveCeiling;
+            inflectionValue *= InflectionPointHeroic;
+            curveFloor = InflectionPointHeroicCurveFloor;
+            curveCeiling = InflectionPointHeroicCurveCeiling;
+        }
+        else if (maxNumberOfPlayers <= 10)
+        {
+            inflectionValue *= InflectionPointRaid10MHeroic;
+            curveFloor = InflectionPointRaid10MHeroicCurveFloor;
+            curveCeiling = InflectionPointRaid10MHeroicCurveCeiling;
+        }
+        else if (maxNumberOfPlayers <= 25)
+        {
+            inflectionValue *= InflectionPointRaid25MHeroic;
+            curveFloor = InflectionPointRaid25MHeroicCurveFloor;
+            curveCeiling = InflectionPointRaid25MHeroicCurveCeiling;
+        }
+        else
+        {
+            inflectionValue *= InflectionPointRaidHeroic;
+            curveFloor = InflectionPointRaidHeroicCurveFloor;
+            curveCeiling = InflectionPointRaidHeroicCurveCeiling;
         }
     }
     else
     {
-        switch (maxNumberOfPlayers)
+        if (maxNumberOfPlayers <= 5)
         {
-            case 1:
-            case 2:
-            case 3:
-            case 4:
-            case 5:
-                inflectionValue *= InflectionPoint;
-                curveFloor = InflectionPointCurveFloor;
-                curveCeiling = InflectionPointCurveCeiling;
-                break;
-            case 10:
-                inflectionValue *= InflectionPointRaid10M;
-                curveFloor = InflectionPointRaid10MCurveFloor;
-                curveCeiling = InflectionPointRaid10MCurveCeiling;
-                break;
-            case 15:
-                inflectionValue *= InflectionPointRaid15M;
-                curveFloor = InflectionPointRaid15MCurveFloor;
-                curveCeiling = InflectionPointRaid15MCurveCeiling;
-                break;
-            case 20:
-                inflectionValue *= InflectionPointRaid20M;
-                curveFloor = InflectionPointRaid20MCurveFloor;
-                curveCeiling = InflectionPointRaid20MCurveCeiling;
-                break;
-            case 25:
-                inflectionValue *= InflectionPointRaid25M;
-                curveFloor = InflectionPointRaid25MCurveFloor;
-                curveCeiling = InflectionPointRaid25MCurveCeiling;
-                break;
-            case 40:
-                inflectionValue *= InflectionPointRaid40M;
-                curveFloor = InflectionPointRaid40MCurveFloor;
-                curveCeiling = InflectionPointRaid40MCurveCeiling;
-                break;
-            default:
-                inflectionValue *= InflectionPointRaid;
-                curveFloor = InflectionPointRaidCurveFloor;
-                curveCeiling = InflectionPointRaidCurveCeiling;
+            inflectionValue *= InflectionPoint;
+            curveFloor = InflectionPointCurveFloor;
+            curveCeiling = InflectionPointCurveCeiling;
+        }
+        else if (maxNumberOfPlayers <= 10)
+        {
+            inflectionValue *= InflectionPointRaid10M;
+            curveFloor = InflectionPointRaid10MCurveFloor;
+            curveCeiling = InflectionPointRaid10MCurveCeiling;
+        }
+        else if (maxNumberOfPlayers <= 15)
+        {
+            inflectionValue *= InflectionPointRaid15M;
+            curveFloor = InflectionPointRaid15MCurveFloor;
+            curveCeiling = InflectionPointRaid15MCurveCeiling;
+        }
+        else if (maxNumberOfPlayers <= 20)
+        {
+            inflectionValue *= InflectionPointRaid20M;
+            curveFloor = InflectionPointRaid20MCurveFloor;
+            curveCeiling = InflectionPointRaid20MCurveCeiling;
+        }
+        else if (maxNumberOfPlayers <= 25)
+        {
+            inflectionValue *= InflectionPointRaid25M;
+            curveFloor = InflectionPointRaid25MCurveFloor;
+            curveCeiling = InflectionPointRaid25MCurveCeiling;
+        }
+        else if (maxNumberOfPlayers <= 40)
+        {
+            inflectionValue *= InflectionPointRaid40M;
+            curveFloor = InflectionPointRaid40MCurveFloor;
+            curveCeiling = InflectionPointRaid40MCurveCeiling;
+        }
+        else
+        {
+            inflectionValue *= InflectionPointRaid;
+            curveFloor = InflectionPointRaidCurveFloor;
+            curveCeiling = InflectionPointRaidCurveCeiling;
         }
     }
 
@@ -1185,56 +1188,54 @@ AutoBalanceInflectionPointSettings getInflectionPointSettings (InstanceMap* inst
 
         float bossInflectionPointMultiplier;
 
-        // Determine the correct boss inflection multiplier
         if (instanceMap->IsHeroic())
         {
-            switch (maxNumberOfPlayers)
+            if (maxNumberOfPlayers <= 5)
             {
-                case 1:
-                case 2:
-                case 3:
-                case 4:
-                case 5:
-                    bossInflectionPointMultiplier = InflectionPointHeroicBoss;
-                    break;
-                case 10:
-                    bossInflectionPointMultiplier = InflectionPointRaid10MHeroicBoss;
-                    break;
-                case 25:
-                    bossInflectionPointMultiplier = InflectionPointRaid25MHeroicBoss;
-                    break;
-                default:
-                    bossInflectionPointMultiplier = InflectionPointRaidHeroicBoss;
+                bossInflectionPointMultiplier = InflectionPointHeroicBoss;
+            }
+            else if (maxNumberOfPlayers <= 10)
+            {
+                bossInflectionPointMultiplier = InflectionPointRaid10MHeroicBoss;
+            }
+            else if (maxNumberOfPlayers <= 25)
+            {
+                bossInflectionPointMultiplier = InflectionPointRaid25MHeroicBoss;
+            }
+            else
+            {
+                bossInflectionPointMultiplier = InflectionPointRaidHeroicBoss;
             }
         }
         else
         {
-            switch (maxNumberOfPlayers)
+            if (maxNumberOfPlayers <= 5)
             {
-                case 1:
-                case 2:
-                case 3:
-                case 4:
-                case 5:
-                    bossInflectionPointMultiplier = InflectionPointBoss;
-                    break;
-                case 10:
-                    bossInflectionPointMultiplier = InflectionPointRaid10MBoss;
-                    break;
-                case 15:
-                    bossInflectionPointMultiplier = InflectionPointRaid15MBoss;
-                    break;
-                case 20:
-                    bossInflectionPointMultiplier = InflectionPointRaid20MBoss;
-                    break;
-                case 25:
-                    bossInflectionPointMultiplier = InflectionPointRaid25MBoss;
-                    break;
-                case 40:
-                    bossInflectionPointMultiplier = InflectionPointRaid40MBoss;
-                    break;
-                default:
-                    bossInflectionPointMultiplier = InflectionPointRaidBoss;
+                bossInflectionPointMultiplier = InflectionPointBoss;
+            }
+            else if (maxNumberOfPlayers <= 10)
+            {
+                bossInflectionPointMultiplier = InflectionPointRaid10MBoss;
+            }
+            else if (maxNumberOfPlayers <= 15)
+            {
+                bossInflectionPointMultiplier = InflectionPointRaid15MBoss;
+            }
+            else if (maxNumberOfPlayers <= 20)
+            {
+                bossInflectionPointMultiplier = InflectionPointRaid20MBoss;
+            }
+            else if (maxNumberOfPlayers <= 25)
+            {
+                bossInflectionPointMultiplier = InflectionPointRaid25MBoss;
+            }
+            else if (maxNumberOfPlayers <= 40)
+            {
+                bossInflectionPointMultiplier = InflectionPointRaid40MBoss;
+            }
+            else
+            {
+                bossInflectionPointMultiplier = InflectionPointRaidBoss;
             }
         }
 
@@ -1317,333 +1318,283 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
     // AutoBalance.StatModifier*(.Boss).<stat>
     if (instanceMap->IsHeroic()) // heroic
     {
-        switch (maxNumberOfPlayers)
+        if (maxNumberOfPlayers <= 5)
         {
-            case 1:
-            case 2:
-            case 3:
-            case 4:
-            case 5:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifierHeroic_Boss_Global;
-                    statModifiers.health = StatModifierHeroic_Boss_Health;
-                    statModifiers.mana = StatModifierHeroic_Boss_Mana;
-                    statModifiers.armor = StatModifierHeroic_Boss_Armor;
-                    statModifiers.damage = StatModifierHeroic_Boss_Damage;
-                    statModifiers.ccduration = StatModifierHeroic_Boss_CCDuration;
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifierHeroic_Boss_Global;
+                statModifiers.health = StatModifierHeroic_Boss_Health;
+                statModifiers.mana = StatModifierHeroic_Boss_Mana;
+                statModifiers.armor = StatModifierHeroic_Boss_Armor;
+                statModifiers.damage = StatModifierHeroic_Boss_Damage;
+                statModifiers.ccduration = StatModifierHeroic_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "1 to 5 Player Heroic Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifierHeroic_Global;
-                    statModifiers.health = StatModifierHeroic_Health;
-                    statModifiers.mana = StatModifierHeroic_Mana;
-                    statModifiers.armor = StatModifierHeroic_Armor;
-                    statModifiers.damage = StatModifierHeroic_Damage;
-                    statModifiers.ccduration = StatModifierHeroic_CCDuration;
+                getStatModifiersDebug(map, creature, "1 to 5 Player Heroic Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifierHeroic_Global;
+                statModifiers.health = StatModifierHeroic_Health;
+                statModifiers.mana = StatModifierHeroic_Mana;
+                statModifiers.armor = StatModifierHeroic_Armor;
+                statModifiers.damage = StatModifierHeroic_Damage;
+                statModifiers.ccduration = StatModifierHeroic_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "1 to 5 Player Heroic");
-                }
-                break;
-            case 6:
-            case 7:
-            case 8:
-            case 9:
-            case 10:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifierRaid10MHeroic_Boss_Global;
-                    statModifiers.health = StatModifierRaid10MHeroic_Boss_Health;
-                    statModifiers.mana = StatModifierRaid10MHeroic_Boss_Mana;
-                    statModifiers.armor = StatModifierRaid10MHeroic_Boss_Armor;
-                    statModifiers.damage = StatModifierRaid10MHeroic_Boss_Damage;
-                    statModifiers.ccduration = StatModifierRaid10MHeroic_Boss_CCDuration;
+                getStatModifiersDebug(map, creature, "1 to 5 Player Heroic");
+            }
+        }
+        else if (maxNumberOfPlayers <= 10)
+        {
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifierRaid10MHeroic_Boss_Global;
+                statModifiers.health = StatModifierRaid10MHeroic_Boss_Health;
+                statModifiers.mana = StatModifierRaid10MHeroic_Boss_Mana;
+                statModifiers.armor = StatModifierRaid10MHeroic_Boss_Armor;
+                statModifiers.damage = StatModifierRaid10MHeroic_Boss_Damage;
+                statModifiers.ccduration = StatModifierRaid10MHeroic_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "10 Player Heroic Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifierRaid10MHeroic_Global;
-                    statModifiers.health = StatModifierRaid10MHeroic_Health;
-                    statModifiers.mana = StatModifierRaid10MHeroic_Mana;
-                    statModifiers.armor = StatModifierRaid10MHeroic_Armor;
-                    statModifiers.damage = StatModifierRaid10MHeroic_Damage;
-                    statModifiers.ccduration = StatModifierRaid10MHeroic_CCDuration;
+                getStatModifiersDebug(map, creature, "10 Player Heroic Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifierRaid10MHeroic_Global;
+                statModifiers.health = StatModifierRaid10MHeroic_Health;
+                statModifiers.mana = StatModifierRaid10MHeroic_Mana;
+                statModifiers.armor = StatModifierRaid10MHeroic_Armor;
+                statModifiers.damage = StatModifierRaid10MHeroic_Damage;
+                statModifiers.ccduration = StatModifierRaid10MHeroic_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "10 Player Heroic");
-                }
-                break;
-            case 11:
-            case 12:
-            case 13:
-            case 14:
-            case 15:
-            case 16:
-            case 17:
-            case 18:
-            case 19:
-            case 20:
-            case 21:
-            case 22:
-            case 23:
-            case 24:
-            case 25:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifierRaid25MHeroic_Boss_Global;
-                    statModifiers.health = StatModifierRaid25MHeroic_Boss_Health;
-                    statModifiers.mana = StatModifierRaid25MHeroic_Boss_Mana;
-                    statModifiers.armor = StatModifierRaid25MHeroic_Boss_Armor;
-                    statModifiers.damage = StatModifierRaid25MHeroic_Boss_Damage;
-                    statModifiers.ccduration = StatModifierRaid25MHeroic_Boss_CCDuration;
+                getStatModifiersDebug(map, creature, "10 Player Heroic");
+            }
+        }
+        else if (maxNumberOfPlayers <= 25)
+        {
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifierRaid25MHeroic_Boss_Global;
+                statModifiers.health = StatModifierRaid25MHeroic_Boss_Health;
+                statModifiers.mana = StatModifierRaid25MHeroic_Boss_Mana;
+                statModifiers.armor = StatModifierRaid25MHeroic_Boss_Armor;
+                statModifiers.damage = StatModifierRaid25MHeroic_Boss_Damage;
+                statModifiers.ccduration = StatModifierRaid25MHeroic_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "25 Player Heroic Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifierRaid25MHeroic_Global;
-                    statModifiers.health = StatModifierRaid25MHeroic_Health;
-                    statModifiers.mana = StatModifierRaid25MHeroic_Mana;
-                    statModifiers.armor = StatModifierRaid25MHeroic_Armor;
-                    statModifiers.damage = StatModifierRaid25MHeroic_Damage;
-                    statModifiers.ccduration = StatModifierRaid25MHeroic_CCDuration;
+                getStatModifiersDebug(map, creature, "25 Player Heroic Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifierRaid25MHeroic_Global;
+                statModifiers.health = StatModifierRaid25MHeroic_Health;
+                statModifiers.mana = StatModifierRaid25MHeroic_Mana;
+                statModifiers.armor = StatModifierRaid25MHeroic_Armor;
+                statModifiers.damage = StatModifierRaid25MHeroic_Damage;
+                statModifiers.ccduration = StatModifierRaid25MHeroic_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "25 Player Heroic");
-                }
-                break;
-            default:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifierRaidHeroic_Boss_Global;
-                    statModifiers.health = StatModifierRaidHeroic_Boss_Health;
-                    statModifiers.mana = StatModifierRaidHeroic_Boss_Mana;
-                    statModifiers.armor = StatModifierRaidHeroic_Boss_Armor;
-                    statModifiers.damage = StatModifierRaidHeroic_Boss_Damage;
-                    statModifiers.ccduration = StatModifierRaidHeroic_Boss_CCDuration;
+                getStatModifiersDebug(map, creature, "25 Player Heroic");
+            }
+        }
+        else
+        {
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifierRaidHeroic_Boss_Global;
+                statModifiers.health = StatModifierRaidHeroic_Boss_Health;
+                statModifiers.mana = StatModifierRaidHeroic_Boss_Mana;
+                statModifiers.armor = StatModifierRaidHeroic_Boss_Armor;
+                statModifiers.damage = StatModifierRaidHeroic_Boss_Damage;
+                statModifiers.ccduration = StatModifierRaidHeroic_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "?? Player Heroic Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifierRaidHeroic_Global;
-                    statModifiers.health = StatModifierRaidHeroic_Health;
-                    statModifiers.mana = StatModifierRaidHeroic_Mana;
-                    statModifiers.armor = StatModifierRaidHeroic_Armor;
-                    statModifiers.damage = StatModifierRaidHeroic_Damage;
-                    statModifiers.ccduration = StatModifierRaidHeroic_CCDuration;
+                getStatModifiersDebug(map, creature, "?? Player Heroic Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifierRaidHeroic_Global;
+                statModifiers.health = StatModifierRaidHeroic_Health;
+                statModifiers.mana = StatModifierRaidHeroic_Mana;
+                statModifiers.armor = StatModifierRaidHeroic_Armor;
+                statModifiers.damage = StatModifierRaidHeroic_Damage;
+                statModifiers.ccduration = StatModifierRaidHeroic_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "?? Player Heroic");
-                }
+                getStatModifiersDebug(map, creature, "?? Player Heroic");
+            }
         }
     }
     else // non-heroic
     {
-        // unfortunately, the Windows C++ compiler doesn't support switch statements with ranges so we're forced to list all the values
-        switch (maxNumberOfPlayers)
+        if (maxNumberOfPlayers <= 5)
         {
-            case 1:
-            case 2:
-            case 3:
-            case 4:
-            case 5:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifier_Boss_Global;
-                    statModifiers.health = StatModifier_Boss_Health;
-                    statModifiers.mana = StatModifier_Boss_Mana;
-                    statModifiers.armor = StatModifier_Boss_Armor;
-                    statModifiers.damage = StatModifier_Boss_Damage;
-                    statModifiers.ccduration = StatModifier_Boss_CCDuration;
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifier_Boss_Global;
+                statModifiers.health = StatModifier_Boss_Health;
+                statModifiers.mana = StatModifier_Boss_Mana;
+                statModifiers.armor = StatModifier_Boss_Armor;
+                statModifiers.damage = StatModifier_Boss_Damage;
+                statModifiers.ccduration = StatModifier_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "1 to 5 Player Normal Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifier_Global;
-                    statModifiers.health = StatModifier_Health;
-                    statModifiers.mana = StatModifier_Mana;
-                    statModifiers.armor = StatModifier_Armor;
-                    statModifiers.damage = StatModifier_Damage;
-                    statModifiers.ccduration = StatModifier_CCDuration;
+                getStatModifiersDebug(map, creature, "1 to 5 Player Normal Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifier_Global;
+                statModifiers.health = StatModifier_Health;
+                statModifiers.mana = StatModifier_Mana;
+                statModifiers.armor = StatModifier_Armor;
+                statModifiers.damage = StatModifier_Damage;
+                statModifiers.ccduration = StatModifier_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "1 to 5 Player Normal");
-                }
-                break;
-            case 6:
-            case 7:
-            case 8:
-            case 9:
-            case 10:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifierRaid10M_Boss_Global;
-                    statModifiers.health = StatModifierRaid10M_Boss_Health;
-                    statModifiers.mana = StatModifierRaid10M_Boss_Mana;
-                    statModifiers.armor = StatModifierRaid10M_Boss_Armor;
-                    statModifiers.damage = StatModifierRaid10M_Boss_Damage;
-                    statModifiers.ccduration = StatModifierRaid10M_Boss_CCDuration;
+                getStatModifiersDebug(map, creature, "1 to 5 Player Normal");
+            }
+        }
+        else if (maxNumberOfPlayers <= 10)
+        {
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifierRaid10M_Boss_Global;
+                statModifiers.health = StatModifierRaid10M_Boss_Health;
+                statModifiers.mana = StatModifierRaid10M_Boss_Mana;
+                statModifiers.armor = StatModifierRaid10M_Boss_Armor;
+                statModifiers.damage = StatModifierRaid10M_Boss_Damage;
+                statModifiers.ccduration = StatModifierRaid10M_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "10 Player Normal Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifierRaid10M_Global;
-                    statModifiers.health = StatModifierRaid10M_Health;
-                    statModifiers.mana = StatModifierRaid10M_Mana;
-                    statModifiers.armor = StatModifierRaid10M_Armor;
-                    statModifiers.damage = StatModifierRaid10M_Damage;
-                    statModifiers.ccduration = StatModifierRaid10M_CCDuration;
+                getStatModifiersDebug(map, creature, "10 Player Normal Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifierRaid10M_Global;
+                statModifiers.health = StatModifierRaid10M_Health;
+                statModifiers.mana = StatModifierRaid10M_Mana;
+                statModifiers.armor = StatModifierRaid10M_Armor;
+                statModifiers.damage = StatModifierRaid10M_Damage;
+                statModifiers.ccduration = StatModifierRaid10M_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "10 Player Normal");
-                }
-                break;
-            case 11:
-            case 12:
-            case 13:
-            case 14:
-            case 15:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifierRaid15M_Boss_Global;
-                    statModifiers.health = StatModifierRaid15M_Boss_Health;
-                    statModifiers.mana = StatModifierRaid15M_Boss_Mana;
-                    statModifiers.armor = StatModifierRaid15M_Boss_Armor;
-                    statModifiers.damage = StatModifierRaid15M_Boss_Damage;
-                    statModifiers.ccduration = StatModifierRaid15M_Boss_CCDuration;
+                getStatModifiersDebug(map, creature, "10 Player Normal");
+            }
+        }
+        else if (maxNumberOfPlayers <= 15)
+        {
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifierRaid15M_Boss_Global;
+                statModifiers.health = StatModifierRaid15M_Boss_Health;
+                statModifiers.mana = StatModifierRaid15M_Boss_Mana;
+                statModifiers.armor = StatModifierRaid15M_Boss_Armor;
+                statModifiers.damage = StatModifierRaid15M_Boss_Damage;
+                statModifiers.ccduration = StatModifierRaid15M_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "15 Player Normal Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifierRaid15M_Global;
-                    statModifiers.health = StatModifierRaid15M_Health;
-                    statModifiers.mana = StatModifierRaid15M_Mana;
-                    statModifiers.armor = StatModifierRaid15M_Armor;
-                    statModifiers.damage = StatModifierRaid15M_Damage;
-                    statModifiers.ccduration = StatModifierRaid15M_CCDuration;
+                getStatModifiersDebug(map, creature, "15 Player Normal Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifierRaid15M_Global;
+                statModifiers.health = StatModifierRaid15M_Health;
+                statModifiers.mana = StatModifierRaid15M_Mana;
+                statModifiers.armor = StatModifierRaid15M_Armor;
+                statModifiers.damage = StatModifierRaid15M_Damage;
+                statModifiers.ccduration = StatModifierRaid15M_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "15 Player Normal");
-                }
-                break;
-            case 16:
-            case 17:
-            case 18:
-            case 19:
-            case 20:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifierRaid20M_Boss_Global;
-                    statModifiers.health = StatModifierRaid20M_Boss_Health;
-                    statModifiers.mana = StatModifierRaid20M_Boss_Mana;
-                    statModifiers.armor = StatModifierRaid20M_Boss_Armor;
-                    statModifiers.damage = StatModifierRaid20M_Boss_Damage;
-                    statModifiers.ccduration = StatModifierRaid20M_Boss_CCDuration;
+                getStatModifiersDebug(map, creature, "15 Player Normal");
+            }
+        }
+        else if (maxNumberOfPlayers <= 20)
+        {
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifierRaid20M_Boss_Global;
+                statModifiers.health = StatModifierRaid20M_Boss_Health;
+                statModifiers.mana = StatModifierRaid20M_Boss_Mana;
+                statModifiers.armor = StatModifierRaid20M_Boss_Armor;
+                statModifiers.damage = StatModifierRaid20M_Boss_Damage;
+                statModifiers.ccduration = StatModifierRaid20M_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "20 Player Normal Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifierRaid20M_Global;
-                    statModifiers.health = StatModifierRaid20M_Health;
-                    statModifiers.mana = StatModifierRaid20M_Mana;
-                    statModifiers.armor = StatModifierRaid20M_Armor;
-                    statModifiers.damage = StatModifierRaid20M_Damage;
-                    statModifiers.ccduration = StatModifierRaid20M_CCDuration;
+                getStatModifiersDebug(map, creature, "20 Player Normal Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifierRaid20M_Global;
+                statModifiers.health = StatModifierRaid20M_Health;
+                statModifiers.mana = StatModifierRaid20M_Mana;
+                statModifiers.armor = StatModifierRaid20M_Armor;
+                statModifiers.damage = StatModifierRaid20M_Damage;
+                statModifiers.ccduration = StatModifierRaid20M_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "20 Player Normal");
-                }
-                break;
-            case 21:
-            case 22:
-            case 23:
-            case 24:
-            case 25:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifierRaid25M_Boss_Global;
-                    statModifiers.health = StatModifierRaid25M_Boss_Health;
-                    statModifiers.mana = StatModifierRaid25M_Boss_Mana;
-                    statModifiers.armor = StatModifierRaid25M_Boss_Armor;
-                    statModifiers.damage = StatModifierRaid25M_Boss_Damage;
-                    statModifiers.ccduration = StatModifierRaid25M_Boss_CCDuration;
+                getStatModifiersDebug(map, creature, "20 Player Normal");
+            }
+        }
+        else if (maxNumberOfPlayers <= 25)
+        {
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifierRaid25M_Boss_Global;
+                statModifiers.health = StatModifierRaid25M_Boss_Health;
+                statModifiers.mana = StatModifierRaid25M_Boss_Mana;
+                statModifiers.armor = StatModifierRaid25M_Boss_Armor;
+                statModifiers.damage = StatModifierRaid25M_Boss_Damage;
+                statModifiers.ccduration = StatModifierRaid25M_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "25 Player Normal Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifierRaid25M_Global;
-                    statModifiers.health = StatModifierRaid25M_Health;
-                    statModifiers.mana = StatModifierRaid25M_Mana;
-                    statModifiers.armor = StatModifierRaid25M_Armor;
-                    statModifiers.damage = StatModifierRaid25M_Damage;
-                    statModifiers.ccduration = StatModifierRaid25M_CCDuration;
+                getStatModifiersDebug(map, creature, "25 Player Normal Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifierRaid25M_Global;
+                statModifiers.health = StatModifierRaid25M_Health;
+                statModifiers.mana = StatModifierRaid25M_Mana;
+                statModifiers.armor = StatModifierRaid25M_Armor;
+                statModifiers.damage = StatModifierRaid25M_Damage;
+                statModifiers.ccduration = StatModifierRaid25M_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "25 Player Normal");
-                }
-                break;
-            case 26:
-            case 27:
-            case 28:
-            case 29:
-            case 30:
-            case 31:
-            case 32:
-            case 33:
-            case 34:
-            case 35:
-            case 36:
-            case 37:
-            case 38:
-            case 39:
-            case 40:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifierRaid40M_Boss_Global;
-                    statModifiers.health = StatModifierRaid40M_Boss_Health;
-                    statModifiers.mana = StatModifierRaid40M_Boss_Mana;
-                    statModifiers.armor = StatModifierRaid40M_Boss_Armor;
-                    statModifiers.damage = StatModifierRaid40M_Boss_Damage;
-                    statModifiers.ccduration = StatModifierRaid40M_Boss_CCDuration;
+                getStatModifiersDebug(map, creature, "25 Player Normal");
+            }
+        }
+        else if (maxNumberOfPlayers <= 40)
+        {
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifierRaid40M_Boss_Global;
+                statModifiers.health = StatModifierRaid40M_Boss_Health;
+                statModifiers.mana = StatModifierRaid40M_Boss_Mana;
+                statModifiers.armor = StatModifierRaid40M_Boss_Armor;
+                statModifiers.damage = StatModifierRaid40M_Boss_Damage;
+                statModifiers.ccduration = StatModifierRaid40M_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "40 Player Normal Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifierRaid40M_Global;
-                    statModifiers.health = StatModifierRaid40M_Health;
-                    statModifiers.mana = StatModifierRaid40M_Mana;
-                    statModifiers.armor = StatModifierRaid40M_Armor;
-                    statModifiers.damage = StatModifierRaid40M_Damage;
-                    statModifiers.ccduration = StatModifierRaid40M_CCDuration;
+                getStatModifiersDebug(map, creature, "40 Player Normal Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifierRaid40M_Global;
+                statModifiers.health = StatModifierRaid40M_Health;
+                statModifiers.mana = StatModifierRaid40M_Mana;
+                statModifiers.armor = StatModifierRaid40M_Armor;
+                statModifiers.damage = StatModifierRaid40M_Damage;
+                statModifiers.ccduration = StatModifierRaid40M_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "40 Player Normal");
-                }
-                break;
-            default:
-                if (creature && isBossOrBossSummon(creature))
-                {
-                    statModifiers.global = StatModifierRaid_Boss_Global;
-                    statModifiers.health = StatModifierRaid_Boss_Health;
-                    statModifiers.mana = StatModifierRaid_Boss_Mana;
-                    statModifiers.armor = StatModifierRaid_Boss_Armor;
-                    statModifiers.damage = StatModifierRaid_Boss_Damage;
-                    statModifiers.ccduration = StatModifierRaid_Boss_CCDuration;
+                getStatModifiersDebug(map, creature, "40 Player Normal");
+            }
+        }
+        else
+        {
+            if (creature && isBossOrBossSummon(creature))
+            {
+                statModifiers.global = StatModifierRaid_Boss_Global;
+                statModifiers.health = StatModifierRaid_Boss_Health;
+                statModifiers.mana = StatModifierRaid_Boss_Mana;
+                statModifiers.armor = StatModifierRaid_Boss_Armor;
+                statModifiers.damage = StatModifierRaid_Boss_Damage;
+                statModifiers.ccduration = StatModifierRaid_Boss_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "?? Player Normal Boss");
-                }
-                else
-                {
-                    statModifiers.global = StatModifierRaid_Global;
-                    statModifiers.health = StatModifierRaid_Health;
-                    statModifiers.mana = StatModifierRaid_Mana;
-                    statModifiers.armor = StatModifierRaid_Armor;
-                    statModifiers.damage = StatModifierRaid_Damage;
-                    statModifiers.ccduration = StatModifierRaid_CCDuration;
+                getStatModifiersDebug(map, creature, "?? Player Normal Boss");
+            }
+            else
+            {
+                statModifiers.global = StatModifierRaid_Global;
+                statModifiers.health = StatModifierRaid_Health;
+                statModifiers.mana = StatModifierRaid_Mana;
+                statModifiers.armor = StatModifierRaid_Armor;
+                statModifiers.damage = StatModifierRaid_Damage;
+                statModifiers.ccduration = StatModifierRaid_CCDuration;
 
-                    getStatModifiersDebug(map, creature, "?? Player Normal");
-                }
+                getStatModifiersDebug(map, creature, "?? Player Normal");
+            }
         }
     }
 
@@ -1679,9 +1630,9 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
 
     // Per-creature modifiers applied last
     // AutoBalance.StatModifier.PerCreature
-    if (creature && hasStatModifierCreatureOverride(creatureABInfo->entry))
+    if (creature && hasStatModifierCreatureOverride(creature->GetEntry()))
     {
-        AutoBalanceStatModifiers* myCreatureOverrides = &statModifierCreatureOverrides[creatureABInfo->entry];
+        AutoBalanceStatModifiers* myCreatureOverrides = &statModifierCreatureOverrides[creature->GetEntry()];
 
         if (myCreatureOverrides->global != -1)      { statModifiers.global =      myCreatureOverrides->global;      }
         if (myCreatureOverrides->health != -1)      { statModifiers.health =      myCreatureOverrides->health;      }
@@ -5203,8 +5154,6 @@ public:
 
             return;
         }
-
-        creatureABInfo->entry = creature->GetEntry();
 
         CreatureBaseStats const* origCreatureBaseStats = sObjectMgr->GetCreatureBaseStats(creatureABInfo->UnmodifiedLevel, creatureTemplate->unit_class);
         CreatureBaseStats const* newCreatureBaseStats = sObjectMgr->GetCreatureBaseStats(creatureABInfo->selectedLevel, creatureTemplate->unit_class);

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -5516,6 +5516,12 @@ public:
             handler->SetSentErrorMessage(true);
             return false;
         }
+        else if (!target->GetMap()->IsDungeon())
+        {
+            handler->PSendSysMessage("That target is not in an instance.");
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
 
         AutoBalanceCreatureInfo *creatureABInfo=target->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo");
 

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -4396,11 +4396,12 @@ class AutoBalance_AllMapScript : public AllMapScript
                     }
                     else
                     {
-                        LOG_ERR("module.AutoBalance", "AutoBalance_AllMapScript::OnCreateMap(): Map {} ({}{}) | Could not determine LFG level ranges for this map. Level will bet set to 0.",
-                        map->GetMapName(),
-                        map->GetId(),
-                        map->GetInstanceId() ? "-" + std::to_string(map->GetInstanceId()) : ""
-                    );
+                        LOG_ERROR("module.AutoBalance", "AutoBalance_AllMapScript::OnCreateMap(): Map {} ({}{}) | Could not determine LFG level ranges for this map. Level will bet set to 0.",
+                            map->GetMapName(),
+                            map->GetId(),
+                            map->GetInstanceId() ? "-" + std::to_string(map->GetInstanceId()) : ""
+                        );
+                    }
                 }
 
                 if (map->GetInstanceId())

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -4365,7 +4365,7 @@ class AutoBalance_AllMapScript : public AllMapScript
                     LFGDungeonEntry const* nonHeroicDungeon = nullptr;
                     if (map->GetDifficulty() == DUNGEON_DIFFICULTY_HEROIC)
                     {
-                        nonHeroicDungeon = GetLFGDungeon(map->GetId(), DUNGEON_DIFFICULTY_HEROIC);
+                        nonHeroicDungeon = GetLFGDungeon(map->GetId(), DUNGEON_DIFFICULTY_NORMAL);
                     }
                     else if (map->GetDifficulty() == RAID_DIFFICULTY_10MAN_HEROIC)
                     {
@@ -4388,6 +4388,13 @@ class AutoBalance_AllMapScript : public AllMapScript
                         mapABInfo->lfgMaxLevel = nonHeroicDungeon->MaxLevel;
                         mapABInfo->lfgTargetLevel = nonHeroicDungeon->TargetLevel;
                     }
+                    else
+                    {
+                        LOG_ERR("module.AutoBalance", "AutoBalance_AllMapScript::OnCreateMap(): Map {} ({}{}) | Could not determine LFG level ranges for this map. Level will bet set to 0.",
+                        map->GetMapName(),
+                        map->GetId(),
+                        map->GetInstanceId() ? "-" + std::to_string(map->GetInstanceId()) : ""
+                    );
                 }
 
                 if (map->GetInstanceId())

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -814,7 +814,7 @@ uint32 getBaseExpansionValueForLevel(const uint32 baseValues[3], uint8 targetLev
     return getBaseExpansionValueForLevel(floatBaseValues, targetLevel);
 }
 
-bool isBossOrBossSummon(Creature* creature)
+bool isBossOrBossSummon(Creature* creature, bool log = false)
 {
     // no creature? not a boss
     if (!creature)
@@ -826,8 +826,18 @@ bool isBossOrBossSummon(Creature* creature)
     // if this creature is a boss, return true
     if (creature->IsDungeonBoss() || creature->isWorldBoss())
     {
+        if (log)
+        {
+            LOG_DEBUG("module.AutoBalance", "AutoBalance::isBossOrBossSummon: {} ({}{}) is a BOSS.",
+                        creature->GetName(),
+                        creature->GetEntry(),
+                        creature->GetInstanceId() ? "-" + std::to_string(creature->GetInstanceId()) : ""
+            );
+        }
+
         return true;
     }
+
 
     // if this creature is a summon of a boss, return true
     if (
@@ -843,32 +853,43 @@ bool isBossOrBossSummon(Creature* creature)
         {
             if (summoner->IsDungeonBoss() || summoner->isWorldBoss())
             {
-                // LOG_DEBUG("module.AutoBalance", "AutoBalance::isBossOrBossSummon: {} ({}{}) is a summon of BOSS {}({}{})",
-                //             creature->GetName(),
-                //             creature->GetEntry(),
-                //             creature->GetInstanceId() ? "-" + std::to_string(creature->GetInstanceId()) : "",
-                //             summoner->GetName(),
-                //             summoner->GetEntry(),
-                //             summoner->GetInstanceId() ? "-" + std::to_string(summoner->GetInstanceId()) : ""
-                // );
+                if (log)
+                {
+                    LOG_DEBUG("module.AutoBalance", "AutoBalance::isBossOrBossSummon: {} ({}) is a summon of BOSS {}({}).",
+                                creature->GetName(),
+                                creature->GetEntry(),
+                                summoner->GetName(),
+                                summoner->GetEntry()
+                    );
+                }
+
                 return true;
             }
             else
             {
-                // LOG_DEBUG("module.AutoBalance", "AutoBalance::isBossOrBossSummon: {} ({}{}) is a summon of NON-BOSS {}({}{})",
-                //             creature->GetName(),
-                //             creature->GetEntry(),
-                //             creature->GetInstanceId() ? "-" + std::to_string(creature->GetInstanceId()) : "",
-                //             summoner->GetName(),
-                //             summoner->GetEntry(),
-                //             summoner->GetInstanceId() ? "-" + std::to_string(summoner->GetInstanceId()) : ""
-                // );
+                if (log)
+                {
+                    LOG_DEBUG("module.AutoBalance", "AutoBalance::isBossOrBossSummon: {} ({}) is a summon of NON-BOSS {}({}).",
+                                creature->GetName(),
+                                creature->GetEntry(),
+                                summoner->GetName(),
+                                summoner->GetEntry()
+                    );
+                }
                 return false;
             }
         }
     }
 
     // not a boss
+    if (log)
+    {
+        LOG_DEBUG("module.AutoBalance", "AutoBalance::isBossOrBossSummon: {} ({}) is NOT a BOSS.",
+                    creature->GetName(),
+                    creature->GetEntry()
+        );
+    }
+
     return false;
 }
 
@@ -4210,7 +4231,7 @@ public:
         if (creatureMap && creatureMap->IsDungeon())
         {
             LOG_DEBUG("module.AutoBalance", "AutoBalance:: {}", SPACER);
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::OnBeforeCreatureSelectLevel: Creature {} ({}) | Entry ID: {} | Spawn ID: {}",
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::OnBeforeCreatureSelectLevel: Creature {} ({}) | Entry ID: ({}) | Spawn ID: ({})",
                         creature->GetName(),
                         level,
                         creature->GetEntry(),
@@ -4325,7 +4346,7 @@ public:
         {
             LOG_DEBUG("module.AutoBalance", "AutoBalance:: {}", SPACER);
 
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::OnCreatureRemoveWorld: Creature {} ({}) | Entry ID: {} | Spawn ID: {}",
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::OnCreatureRemoveWorld: Creature {} ({}) | Entry ID: ({}) | Spawn ID: ({})",
                         creature->GetName(),
                         creature->GetLevel(),
                         creature->GetEntry(),
@@ -4376,7 +4397,7 @@ public:
         {
             LOG_DEBUG("module.AutoBalance", "AutoBalance:: {}", SPACER);
 
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::OnAllCreatureUpdate: Creature {} ({}) | Entry ID: {} | Spawn ID: {}",
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::OnAllCreatureUpdate: Creature {} ({}) | Entry ID: ({}) | Spawn ID: ({})",
                         creature->GetName(),
                         creature->GetLevel(),
                         creature->GetEntry(),
@@ -4445,7 +4466,7 @@ public:
         {
             LOG_DEBUG("module.AutoBalance", "AutoBalance:: {}", SPACER);
 
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::ResetCreatureIfNeeded: Creature {} ({}) | Entry ID: {} | Spawn ID: {}",
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::ResetCreatureIfNeeded: Creature {} ({}) | Entry ID: ({}) | Spawn ID: ({})",
                         creature->GetName(),
                         creature->GetLevel(),
                         creature->GetEntry(),
@@ -4774,6 +4795,9 @@ public:
 
         if (!sABScriptMgr->OnAfterDefaultMultiplier(creature, defaultMultiplier))
             return;
+
+        // Debug for boss detection
+        isBossOrBossSummon(creature, true);
 
         // Stat Modifiers
         AutoBalanceStatModifiers statModifiers = getStatModifiers(map, creature);

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -783,7 +783,7 @@ void AddCreatureToMapData(Creature* creature, bool addToCreatureList = true, Pla
     }
 
     // if this is a non-relevant creature, skip
-    if (creature->IsCritter() || creature->IsTotem() || creature->IsTrigger())
+    if ((creature->IsCritter() && creature->GetLevel() <= 5) || creature->IsTotem() || creature->IsTrigger())
     {
         LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is a critter, totem, or trigger - skip.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
         return;
@@ -2082,7 +2082,7 @@ public:
             return false;
 
         // if this is a non-relevant creature, skip
-        if (creature->IsCritter() || creature->IsTotem() || creature->IsTrigger())
+        if ((creature->IsCritter() && creature->GetLevel() <= 5) || creature->IsTotem() || creature->IsTrigger())
             return false;
 
         // get (or create) the creature and map's info
@@ -2197,7 +2197,7 @@ public:
             return;
 
         // if this is a non-relevant creature, make no changes
-        if (creature->IsCritter() || creature->IsTotem() || creature->IsTrigger())
+        if ((creature->IsCritter() && creature->GetLevel() <= 5) || creature->IsTotem() || creature->IsTrigger())
             return;
 
         // grab creature and map data

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -2540,7 +2540,7 @@ void UpdateMapPlayerStats(Map* map)
     else if (mapABInfo->combatLocked)
     {
         // start with the saved floor
-        adjustedPlayerCount = mapABInfo->combatLockMinPlayers;
+        adjustedPlayerCount = mapABInfo->combatLockMinPlayers ? mapABInfo->combatLockMinPlayers : mapABInfo->playerCount;
 
         LOG_DEBUG("module.AutoBalance_CombatLocking", "AutoBalance::UpdateMapPlayerStats: Map {} ({}{}) | Combat is locked. Combat floor is ({}).",
             instanceMap->GetMapName(),

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -221,7 +221,7 @@ public:
     uint8 levelScalingDynamicCeiling;               // how many levels MORE than the highestPlayerLevel creature should be scaled to
     uint8 levelScalingDynamicFloor;                 // how many levels LESS than the highestPlayerLevel creature should be scaled to
 
-    uint prevMapLevel = 0;                          // used to reduce calculations when they are not necessary
+    uint8 prevMapLevel = 0;                          // used to reduce calculations when they are not necessary
 };
 
 class AutoBalanceStatModifiers : public DataMap::Base

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -807,6 +807,64 @@ uint32 getBaseExpansionValueForLevel(const uint32 baseValues[3], uint8 targetLev
     return getBaseExpansionValueForLevel(floatBaseValues, targetLevel);
 }
 
+bool isBossOrBossSummon(Creature* creature)
+{
+    // no creature? not a boss
+    if (!creature)
+    {
+        LOG_INFO("module.AutoBalance", "AutoBalance::isBossOrBossSummon: Creature is null.");
+        return false;
+    }
+
+    // if this creature is a boss, return true
+    if (creature->IsDungeonBoss() || creature->isWorldBoss())
+    {
+        return true;
+    }
+
+    // if this creature is a summon of a boss, return true
+    if (
+        creature->IsSummon() &&
+        creature->ToTempSummon() &&
+        creature->ToTempSummon()->GetSummoner() &&
+        creature->ToTempSummon()->GetSummoner()->ToCreature()
+        )
+    {
+        Creature* summoner = creature->ToTempSummon()->GetSummoner()->ToCreature();
+
+        if (summoner)
+        {
+            if (summoner->IsDungeonBoss() || summoner->isWorldBoss())
+            {
+                // LOG_DEBUG("module.AutoBalance", "AutoBalance::isBossOrBossSummon: {} ({}{}) is a summon of BOSS {}({}{})",
+                //             creature->GetName(),
+                //             creature->GetEntry(),
+                //             creature->GetInstanceId() ? "-" + std::to_string(creature->GetInstanceId()) : "",
+                //             summoner->GetName(),
+                //             summoner->GetEntry(),
+                //             summoner->GetInstanceId() ? "-" + std::to_string(summoner->GetInstanceId()) : ""
+                // );
+                return true;
+            }
+            else
+            {
+                // LOG_DEBUG("module.AutoBalance", "AutoBalance::isBossOrBossSummon: {} ({}{}) is a summon of NON-BOSS {}({}{})",
+                //             creature->GetName(),
+                //             creature->GetEntry(),
+                //             creature->GetInstanceId() ? "-" + std::to_string(creature->GetInstanceId()) : "",
+                //             summoner->GetName(),
+                //             summoner->GetEntry(),
+                //             summoner->GetInstanceId() ? "-" + std::to_string(summoner->GetInstanceId()) : ""
+                // );
+                return false;
+            }
+        }
+    }
+
+    // not a boss
+    return false;
+}
+
 bool isCreatureRelevant(Creature* creature) {
     // if the creature is gone, return
     if (!creature)
@@ -975,11 +1033,10 @@ bool isCreatureRelevant(Creature* creature) {
     }
 
     // survived to here, creature is relevant
-    // LOG_DEBUG below is executed every Creature update for every world creature, enable carefully
-    // LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::isCreatureRelevant: Creature {} ({}) is relevant.",
-    //             creature->GetName(),
-    //             creatureABInfo->UnmodifiedLevel
-    // );
+    LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::isCreatureRelevant: Creature {} ({}) is relevant. Marked for processing.",
+                creature->GetName(),
+                creatureABInfo->UnmodifiedLevel
+    );
     creatureABInfo->relevance = AUTOBALANCE_RELEVANCE_TRUE;
     return true;
 
@@ -1229,7 +1286,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
         switch (maxNumberOfPlayers)
         {
             case 1 ... 5:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierHeroic_Boss_Global;
                     statModifiers.health = StatModifierHeroic_Boss_Health;
@@ -1253,7 +1310,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                 }
                 break;
             case 6 ... 10:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid10MHeroic_Boss_Global;
                     statModifiers.health = StatModifierRaid10MHeroic_Boss_Health;
@@ -1277,7 +1334,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                 }
                 break;
             case 11 ... 25:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid25MHeroic_Boss_Global;
                     statModifiers.health = StatModifierRaid25MHeroic_Boss_Health;
@@ -1301,7 +1358,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                 }
                 break;
             default:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaidHeroic_Boss_Global;
                     statModifiers.health = StatModifierRaidHeroic_Boss_Health;
@@ -1330,7 +1387,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
         switch (maxNumberOfPlayers)
         {
             case 1 ... 5:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifier_Boss_Global;
                     statModifiers.health = StatModifier_Boss_Health;
@@ -1354,7 +1411,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                 }
                 break;
             case 6 ... 10:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid10M_Boss_Global;
                     statModifiers.health = StatModifierRaid10M_Boss_Health;
@@ -1378,7 +1435,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                 }
                 break;
             case 11 ... 15:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid15M_Boss_Global;
                     statModifiers.health = StatModifierRaid15M_Boss_Health;
@@ -1402,7 +1459,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                 }
                 break;
             case 16 ... 20:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid20M_Boss_Global;
                     statModifiers.health = StatModifierRaid20M_Boss_Health;
@@ -1426,7 +1483,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                 }
                 break;
             case 21 ... 25:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid25M_Boss_Global;
                     statModifiers.health = StatModifierRaid25M_Boss_Health;
@@ -1450,7 +1507,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                 }
                 break;
             case 26 ... 40:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid40M_Boss_Global;
                     statModifiers.health = StatModifierRaid40M_Boss_Health;
@@ -1474,7 +1531,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
                 }
                 break;
             default:
-                if (creature && creature->IsDungeonBoss())
+                if (creature && isBossOrBossSummon(creature))
                 {
                     statModifiers.global = StatModifierRaid_Boss_Global;
                     statModifiers.health = StatModifierRaid_Boss_Health;
@@ -1501,7 +1558,7 @@ AutoBalanceStatModifiers getStatModifiers (Map* map, Creature* creature = nullpt
 
     // Per-Map Overrides
     // AutoBalance.StatModifier.Boss.PerInstance
-    if (creature && creature->IsDungeonBoss() && hasStatModifierBossOverride(mapId))
+    if (creature && isBossOrBossSummon(creature) && hasStatModifierBossOverride(mapId))
     {
         AutoBalanceStatModifiers* myStatModifierBossOverrides = &statModifierBossOverrides[mapId];
 
@@ -2209,7 +2266,7 @@ void AddCreatureToMapCreatureList(Creature* creature, bool addToCreatureList = t
                     creature->HasNpcFlag(UNIT_NPC_FLAG_REPAIR) ||
                     creature->HasUnitFlag(UNIT_FLAG_IMMUNE_TO_PC) ||
                     creature->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE)) &&
-                    (!creature->IsDungeonBoss())
+                    (!isBossOrBossSummon(creature))
                 )
             {
                 LOG_DEBUG("module.AutoBalance", "AutoBalance::AddCreatureToMapCreatureList: Creature {} ({}) is a a vendor, trainer, or is otherwise not attackable - do not include in map stats.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
@@ -2229,7 +2286,7 @@ void AddCreatureToMapCreatureList(Creature* creature, bool addToCreatureList = t
                     }
 
                     // if the creature is friendly and not a boss
-                    if (creature->IsFriendlyTo(thisPlayer) && !creature->IsDungeonBoss())
+                    if (creature->IsFriendlyTo(thisPlayer) && !isBossOrBossSummon(creature))
                     {
                         LOG_DEBUG("module.AutoBalance", "AutoBalance::AddCreatureToMapCreatureList: Creature {} ({}) is friendly to {} - do not include in map stats.",
                             creature->GetName(),
@@ -4658,7 +4715,7 @@ public:
         CreatureBaseStats const* newCreatureBaseStats = sObjectMgr->GetCreatureBaseStats(creatureABInfo->selectedLevel, creatureTemplate->unit_class);
 
         // Inflection Point
-        AutoBalanceInflectionPointSettings inflectionPointSettings = getInflectionPointSettings(instanceMap, creature->IsDungeonBoss());
+        AutoBalanceInflectionPointSettings inflectionPointSettings = getInflectionPointSettings(instanceMap, isBossOrBossSummon(creature));
 
         // Generate the default multiplier
         float defaultMultiplier = getDefaultMultiplier(instanceMap, inflectionPointSettings);
@@ -5530,7 +5587,7 @@ public:
                                   target->GetName(),
                                   creatureABInfo->UnmodifiedLevel,
                                   !creatureABInfo->skipMe && creatureABInfo->UnmodifiedLevel != target->GetLevel() ? "->" + std::to_string(creatureABInfo->selectedLevel) : "",
-                                  target->IsDungeonBoss() ? " | Boss" : "",
+                                  isBossOrBossSummon(target) ? " | Boss" : "",
                                   creatureABInfo->isActive ? "Active for Map Stats" : "Ignored for Map Stats");
         // level scaled
         if (creatureABInfo->UnmodifiedLevel != target->GetLevel())

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -2311,8 +2311,14 @@ void AddCreatureToMapCreatureList(Creature* creature, bool addToCreatureList = t
     if (isCreatureAlreadyInCreatureList && !forceRecalculation)
     {
         LOG_DEBUG("module.AutoBalance", "AutoBalance::AddCreatureToMapCreatureList: Creature {} ({}) | is already included in map stats.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
-        return;
 
+        // ensure that this creature is marked active
+        creatureABInfo->isActive = true;
+
+        // increment the active creature counter
+        mapABInfo->activeCreatureCount++;
+
+        return;
     }
 
     // only do these additional checks if we still think they need to be applied to the map stats
@@ -3086,9 +3092,9 @@ class AutoBalance_WorldScript : public WorldScript
         EnableOtherNormal = sConfigMgr->GetOption<bool>("AutoBalance.Enable.OtherNormal", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
 
         Enable5MHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.5MHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
-        Enable10MHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.5MHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
-        Enable25MHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.5MHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
-        EnableOtherHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.5MHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        Enable10MHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.10MHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        Enable25MHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.25MHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
+        EnableOtherHeroic = sConfigMgr->GetOption<bool>("AutoBalance.Enable.OtherHeroic", sConfigMgr->GetOption<bool>("AutoBalance.enable", 1, false));
 
         // Deprecated setting warning
         if (sConfigMgr->GetOption<int>("AutoBalance.DungeonsOnly", -1, false) != -1)

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -222,7 +222,7 @@ enum BaseValueType {
     AUTOBALANCE_DAMAGE_HEALING
 };
 
-// create a static list of spell IDs that cost health to cast. I will provide the spell IDs, use 5 examples.
+// spell IDs that spend player health
 static std::list<uint32> spellIdsThatSpendPlayerHealth =
 {
     45529,      // Blood Tap
@@ -1479,7 +1479,7 @@ void AddCreatureToMapData(Creature* creature, bool addToCreatureList = true, Pla
         // handle summoned creatures
         if (creature->IsSummon())
         {
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): Creature {} ({}->\?\?) is a summon.", creature->GetName(), creature->GetLevel());
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): Creature {} ({}->\?\?) is a summon.", creature->GetName(), creature->GetLevel());
             if (creature->ToTempSummon() &&
                 creature->ToTempSummon()->GetSummoner() &&
                 creature->ToTempSummon()->GetSummoner()->ToCreature())
@@ -1488,7 +1488,7 @@ void AddCreatureToMapData(Creature* creature, bool addToCreatureList = true, Pla
                 if (!summoner)
                 {
                     creatureABInfo->UnmodifiedLevel = mapABInfo->avgCreatureLevel;
-                    LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): Summoned creature {} ({}) is not owned by a summoner.", creature->GetName(), creature->GetLevel());
+                    LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): Summoned creature {} ({}) is not owned by a summoner.", creature->GetName(), creature->GetLevel());
                 }
                 else
                 {
@@ -1498,23 +1498,23 @@ void AddCreatureToMapData(Creature* creature, bool addToCreatureList = true, Pla
                     if (summonerABInfo->UnmodifiedLevel != summoner->GetLevel())
                     {
                         creatureABInfo->UnmodifiedLevel = summonerABInfo->UnmodifiedLevel;
-                        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): Summoned creature {} ({}) owned by {} ({}->{})", creature->GetName(), creature->GetLevel(), summonerCreature->GetName(), summonerABInfo->UnmodifiedLevel, summonerCreature->GetLevel());
+                        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): Summoned creature {} ({}) owned by {} ({}->{})", creature->GetName(), creature->GetLevel(), summonerCreature->GetName(), summonerABInfo->UnmodifiedLevel, summonerCreature->GetLevel());
                     }
                     else
                     {
                         creatureABInfo->UnmodifiedLevel = summonerCreature->GetLevel();
-                        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): Summoned creature {} ({}) owned by {} ({})", creature->GetName(), creature->GetLevel(), summonerCreature->GetName(), summonerCreature->GetLevel());
+                        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): Summoned creature {} ({}) owned by {} ({})", creature->GetName(), creature->GetLevel(), summonerCreature->GetName(), summonerCreature->GetLevel());
                     }
                 }
             }
             else
             {
                 creatureABInfo->UnmodifiedLevel = mapABInfo->avgCreatureLevel;
-                LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): Summoned creature {} ({}) does not have a summoner.", creature->GetName(), creature->GetLevel());
+                LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): Summoned creature {} ({}) does not have a summoner.", creature->GetName(), creature->GetLevel());
             }
 
             // if this is a summon, we shouldn't track it in any list and it does not contribute to the average level
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): Summoned creature {} ({}) will not affect the map's stats.", creature->GetName(), creature->GetLevel());
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): Summoned creature {} ({}) will not affect the map's stats.", creature->GetName(), creature->GetLevel());
             return;
 
         }
@@ -1522,35 +1522,35 @@ void AddCreatureToMapData(Creature* creature, bool addToCreatureList = true, Pla
         else
         {
             creatureABInfo->UnmodifiedLevel = creature->GetLevel();
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({})", creature->GetName(), creatureABInfo->UnmodifiedLevel);
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({})", creature->GetName(), creatureABInfo->UnmodifiedLevel);
         }
     }
 
     // if this is a creature controlled by the player, skip
     if (((creature->IsHunterPet() || creature->IsPet() || creature->IsSummon()) && creature->IsControlledByPlayer()))
     {
-        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is controlled by the player - skip.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
+        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is controlled by the player - skip.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
         return;
     }
 
     // if this is a non-relevant creature, skip
     if ((creature->IsCritter() && creature->GetLevel() <= 5) || creature->IsTotem() || creature->IsTrigger())
     {
-        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is a critter, totem, or trigger - skip.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
+        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is a critter, totem, or trigger - skip.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
         return;
     }
 
     // if the creature level is below 85% of the minimum LFG level, assume it's a flavor creature and shouldn't be tracked or modified
     if (creatureABInfo->UnmodifiedLevel < ((float)mapABInfo->lfgMinLevel * .85f))
     {
-        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is below 85% of the LFG min level of {} and is NOT tracked.", creature->GetName(), creatureABInfo->UnmodifiedLevel, mapABInfo->lfgMinLevel);
+        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is below 85% of the LFG min level of {} and is NOT tracked.", creature->GetName(), creatureABInfo->UnmodifiedLevel, mapABInfo->lfgMinLevel);
         return;
     }
 
     // if the creature level is above 125% of the maximum LFG level, assume it's a flavor creature or holiday boss and shouldn't be tracked or modified
     if (creatureABInfo->UnmodifiedLevel > ((float)mapABInfo->lfgMaxLevel * 1.15f))
     {
-        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is above 115% of the LFG max level of {} and is NOT tracked.", creature->GetName(), creatureABInfo->UnmodifiedLevel, mapABInfo->lfgMaxLevel);
+        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is above 115% of the LFG max level of {} and is NOT tracked.", creature->GetName(), creatureABInfo->UnmodifiedLevel, mapABInfo->lfgMaxLevel);
         return;
     }
 
@@ -1562,7 +1562,7 @@ void AddCreatureToMapData(Creature* creature, bool addToCreatureList = true, Pla
     {
         mapABInfo->allMapCreatures.push_back(creature);
         creatureABInfo->isInCreatureList = true;
-        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is creature #{} in the creature list.", creature->GetName(), creatureABInfo->UnmodifiedLevel, mapABInfo->allMapCreatures.size());
+        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is creature #{} in the creature list.", creature->GetName(), creatureABInfo->UnmodifiedLevel, mapABInfo->allMapCreatures.size());
     }
 
     // alter stats for the map if needed
@@ -1593,7 +1593,7 @@ void AddCreatureToMapData(Creature* creature, bool addToCreatureList = true, Pla
                     (!creature->IsDungeonBoss())
                 )
             {
-                LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is a a vendor, trainer, or is otherwise not attackable - do not include in map stats.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
+                LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is a a vendor, trainer, or is otherwise not attackable - do not include in map stats.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
                 isIncludedInMapStats = false;
             }
             else
@@ -1612,7 +1612,7 @@ void AddCreatureToMapData(Creature* creature, bool addToCreatureList = true, Pla
                     // if the creature is friendly and not a boss
                     if (creature->IsFriendlyTo(playerHandle) && !creature->IsDungeonBoss())
                     {
-                        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is friendly to {} - do not include in map stats.", creature->GetName(), creatureABInfo->UnmodifiedLevel, playerHandle->GetName());
+                        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is friendly to {} - do not include in map stats.", creature->GetName(), creatureABInfo->UnmodifiedLevel, playerHandle->GetName());
                         isIncludedInMapStats = false;
                         break;
                     }
@@ -1636,13 +1636,13 @@ void AddCreatureToMapData(Creature* creature, bool addToCreatureList = true, Pla
 
                         if (playerHandle->IsWithinDist(creature, 500))
                         {
-                            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is in range ({} world units) of player {} and is considered active.", creature->GetName(), creatureABInfo->UnmodifiedLevel, distance, playerHandle->GetName());
+                            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is in range ({} world units) of player {} and is considered active.", creature->GetName(), creatureABInfo->UnmodifiedLevel, distance, playerHandle->GetName());
                             isPlayerWithinDistance = true;
                             break;
                         }
                         else
                         {
-                            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is NOT in range ({} world units) of any player and is NOT considered active.", creature->GetName(), creature->GetLevel(), distance);
+                            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is NOT in range ({} world units) of any player and is NOT considered active.", creature->GetName(), creature->GetLevel(), distance);
                         }
                     }
 
@@ -1672,22 +1672,22 @@ void AddCreatureToMapData(Creature* creature, bool addToCreatureList = true, Pla
             // increment the active creature counter
             mapABInfo->activeCreatureCount++;
 
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is included in map stats, adjusting avgCreatureLevel to {}", creature->GetName(), creatureABInfo->UnmodifiedLevel, newAvgCreatureLevel);
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is included in map stats, adjusting avgCreatureLevel to {}", creature->GetName(), creatureABInfo->UnmodifiedLevel, newAvgCreatureLevel);
 
             // reset the last config time so that the map data will get updated
             lastConfigTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): lastConfigTime reset to {}", lastConfigTime);
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): lastConfigTime reset to {}", lastConfigTime);
         }
         else if (isCreatureAlreadyInCreatureList)
         {
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is already included in map stats.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is already included in map stats.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
         }
         else
         {
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): {} ({}) is NOT included in map stats.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): {} ({}) is NOT included in map stats.", creature->GetName(), creatureABInfo->UnmodifiedLevel);
         }
 
-        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::AddCreatureToMapData(): There are {} active creatures.", mapABInfo->activeCreatureCount);
+        LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::AddCreatureToMapData(): There are {} active creatures.", mapABInfo->activeCreatureCount);
     }
 }
 
@@ -1703,7 +1703,7 @@ void RemoveCreatureFromMapData(Creature* creature)
         {
             if (*creatureIteration == creature)
             {
-                LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreature::RemoveCreatureFromMapData(): {} ({}) is in the creature list and will be removed. There are {} creatures left.", creature->GetName(), creature->GetLevel(), mapABInfo->allMapCreatures.size() - 1);
+                LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::RemoveCreatureFromMapData(): {} ({}) is in the creature list and will be removed. There are {} creatures left.", creature->GetName(), creature->GetLevel(), mapABInfo->allMapCreatures.size() - 1);
                 mapABInfo->allMapCreatures.erase(creatureIteration);
 
                 // mark this creature as removed
@@ -1821,9 +1821,11 @@ void UpdateMapDataIfNeeded(Map* map)
         }
 
         // Update World Damage or Healing multiplier
+        // Used for scaling damage and healing between players and/or units
         mapABInfo->worldDamageHealingMultiplier = getWorldMultiplier(map, BaseValueType::AUTOBALANCE_DAMAGE_HEALING);
 
         // Update World Health multiplier
+        // Used for scaling damage against destructible game objects
         mapABInfo->worldHealthMultiplier = getWorldMultiplier(map, BaseValueType::AUTOBALANCE_HEALTH);
 
         // mark the config updated
@@ -2419,301 +2421,355 @@ class AutoBalance_PlayerScript : public PlayerScript
 class AutoBalance_UnitScript : public UnitScript
 {
     public:
-    AutoBalance_UnitScript()
-        : UnitScript("AutoBalance_UnitScript", true)
-    {
-    }
-
-    bool debug_damage_and_healing = true;
-
-    void OnHeal(Unit* source, Unit* target, uint32& amount) override
-    {
-        // bool debug_damage_and_healing = (source && target && (source->GetTypeId() == TYPEID_PLAYER || target->GetTypeId() == TYPEID_PLAYER))
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::OnHeal(): BEFORE: {} +{} {}", source->GetName(), amount, target->GetName());
-
-        //amount = _Modify_Damage_Healing(receiver, healer, amount);
-
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::OnHeal(): AFTER: {} +{} {}", source->GetName(), amount, target->GetName());
-    }
-
-    void OnDamage(Unit* source, Unit* target, uint32& amount) override
-    {
-        // bool debug_damage_and_healing = (source && target && (source->GetTypeId() == TYPEID_PLAYER || target->GetTypeId() == TYPEID_PLAYER))
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::OnDamage(): BEFORE: {} -{} {}", source->GetName(), amount, target->GetName());
-
-        // amount = _Modify_Damage(source, target, amount);
-
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::OnDamage(): AFTER: {} -{} {}", source->GetName(), amount, target->GetName());
-    }
-
-    uint32 DealDamage(Unit* source, Unit* target, uint32 amount, DamageEffectType /*damagetype*/) override
-    {
-        // bool debug_damage_and_healing = (source && target && (source->GetTypeId() == TYPEID_PLAYER || target->GetTypeId() == TYPEID_PLAYER))
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::DealDamage(): BEFORE: {} -{} {}", source->GetName(), amount, target->GetName());
-
-        // amount = _Modify_Damage(source, target, amount);
-
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::DealDamage(): AFTER: {} -{} {}", source->GetName(), amount, target->GetName());
-
-        return amount;
-    }
-
-    void ModifyPeriodicDamageAurasTick(Unit* target, Unit* source, uint32& amount, SpellInfo const* /*spellInfo*/) override
-    {
-        // bool debug_damage_and_healing = (source && target && (source->GetTypeId() == TYPEID_PLAYER || target->GetTypeId() == TYPEID_PLAYER))
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::ModifyPeriodicDamageAurasTick(): BEFORE: {} -{} {}", source->GetName(), amount, target->GetName());
-
-        amount = _Modify_Damage_Healing(target, source, amount * -1) * -1;
-
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::ModifyPeriodicDamageAurasTick(): AFTER: {} -{} {}", source->GetName(), amount, target->GetName());
-    }
-
-    void ModifySpellDamageTaken(Unit* target, Unit* source, int32& amount, SpellInfo const* /*spellInfo*/) override
-    {
-        // bool debug_damage_and_healing = (source && target && (source->GetTypeId() == TYPEID_PLAYER || target->GetTypeId() == TYPEID_PLAYER))
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::ModifySpellDamageTaken(): BEFORE: {} -{} {}", source->GetName(), amount, target->GetName());
-
-        amount = _Modify_Damage_Healing(target, source, amount * -1) * -1;
-
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::ModifySpellDamageTaken(): AFTER: {} -{} {}", source->GetName(), amount, target->GetName());
-    }
-
-    void ModifyMeleeDamage(Unit* target, Unit* source, uint32& amount) override
-    {
-        // bool debug_damage_and_healing = (source && target && (source->GetTypeId() == TYPEID_PLAYER || target->GetTypeId() == TYPEID_PLAYER))
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::ModifyMeleeDamage(): BEFORE: {} -{} {}", source->GetName(), amount, target->GetName());
-
-        amount = _Modify_Damage_Healing(target, source, amount * -1) * -1;
-
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::ModifyMeleeDamage(): AFTER: {} -{} {}", source->GetName(), amount, target->GetName());
-    }
-
-    void ModifyHealReceived(Unit* target, Unit* source, uint32& amount, SpellInfo const* /*spellInfo*/) override
-    {
-        // bool debug_damage_and_healing = (source && target && (source->GetTypeId() == TYPEID_PLAYER || target->GetTypeId() == TYPEID_PLAYER))
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::ModifyHealReceived(): BEFORE: {} -{} {}", source->GetName(), amount, target->GetName());
-
-        amount = _Modify_Damage_Healing(target, source, amount);
-
-        if (debug_damage_and_healing)
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::ModifyHealReceived(): AFTER: {} -{} {}", source->GetName(), amount, target->GetName());
-    }
-
-    void OnAuraApply(Unit* unit, Aura* aura) override {
-        // Only if this aura has a duration
-        if (aura->GetDuration() > 0 || aura->GetMaxDuration() > 0)
+        AutoBalance_UnitScript()
+            : UnitScript("AutoBalance_UnitScript", true)
         {
-            uint32 auraDuration = _Modifier_CCDuration(unit, aura->GetCaster(), aura);
+        }
 
-            // only update if we decided to change it
-            if (auraDuration != (float)aura->GetDuration())
+        void ModifyPeriodicDamageAurasTick(Unit* target, Unit* source, uint32& amount, SpellInfo const* spellInfo) override
+        {
+            // if the spell is negative (damage), we need to flip the sign
+            // if the spell is positive (healing or other) we keep it the same
+            int32 adjustedAmount = !spellInfo->IsPositive() ? amount * -1 : amount;
+            
+            // uncomment to debug this hook
+            bool _debug_damage_and_healing = ((source && source->GetTypeId() == TYPEID_PLAYER) || (target && target->GetTypeId() == TYPEID_PLAYER));
+            
+            if (_debug_damage_and_healing) _Debug_Output("ModifyPeriodicDamageAurasTick", target, source, adjustedAmount, "BEFORE:", spellInfo->SpellName[0], spellInfo->Id);
+
+            // set amount to the absolute value of the function call
+            // the provided amount doesn't indicate whether it's a positive or negative value
+            adjustedAmount = _Modify_Damage_Healing(target, source, adjustedAmount);
+            amount = abs(adjustedAmount);
+
+            if (_debug_damage_and_healing) _Debug_Output("ModifyPeriodicDamageAurasTick", target, source, adjustedAmount, "AFTER:", spellInfo->SpellName[0], spellInfo->Id);
+        }
+
+        void ModifySpellDamageTaken(Unit* target, Unit* source, int32& amount, SpellInfo const* spellInfo) override
+        {
+            // if the spell is negative (damage), we need to flip the sign
+            // if the spell is positive (healing or other) we keep it the same
+            int32 adjustedAmount = !spellInfo->IsPositive() ? amount * -1 : amount;
+            
+            // uncomment to debug this hook
+            bool _debug_damage_and_healing = ((source && source->GetTypeId() == TYPEID_PLAYER) || (target && target->GetTypeId() == TYPEID_PLAYER));
+            
+            if (_debug_damage_and_healing) _Debug_Output("ModifySpellDamageTaken", target, source, adjustedAmount, "BEFORE:", spellInfo->SpellName[0], spellInfo->Id);
+
+            // set amount to the absolute value of the function call
+            // the provided amount doesn't indicate whether it's a positive or negative value
+            adjustedAmount = _Modify_Damage_Healing(target, source, adjustedAmount);
+            amount = abs(adjustedAmount);
+
+            if (_debug_damage_and_healing) _Debug_Output("ModifySpellDamageTaken", target, source, adjustedAmount, "AFTER:", spellInfo->SpellName[0], spellInfo->Id);
+        }
+
+        void ModifyMeleeDamage(Unit* target, Unit* source, uint32& amount) override
+        {
+            // melee damage is always negative, so we need to flip the sign
+            int32 adjustedAmount = amount * -1;
+            
+            // uncomment to debug this hook
+            bool _debug_damage_and_healing = ((source && source->GetTypeId() == TYPEID_PLAYER) || (target && target->GetTypeId() == TYPEID_PLAYER));
+            
+            if (_debug_damage_and_healing) _Debug_Output("ModifyMeleeDamage", target, source, adjustedAmount, "BEFORE:", "Melee");
+
+            // set amount to the absolute value of the function call
+            adjustedAmount = _Modify_Damage_Healing(target, source, adjustedAmount);
+            amount = abs(adjustedAmount);
+            
+            if (_debug_damage_and_healing) _Debug_Output("ModifyMeleeDamage", target, source, adjustedAmount, "AFTER:", "Melee");
+        }
+
+        void ModifyHealReceived(Unit* target, Unit* source, uint32& amount, SpellInfo const* spellInfo) override
+        {         
+            // healing is always positive, no need for any sign flip
+            
+            // uncomment to debug this hook
+            bool _debug_damage_and_healing = ((source && source->GetTypeId() == TYPEID_PLAYER) || (target && target->GetTypeId() == TYPEID_PLAYER));
+            
+            if (_debug_damage_and_healing) _Debug_Output("ModifyHealReceived", target, source, amount, "BEFORE:", spellInfo->SpellName[0], spellInfo->Id);
+
+            amount = _Modify_Damage_Healing(target, source, amount);
+
+            if (_debug_damage_and_healing) _Debug_Output("ModifyHealReceived", target, source, amount, "AFTER:", spellInfo->SpellName[0], spellInfo->Id);
+        }
+
+        void OnAuraApply(Unit* unit, Aura* aura) override {
+            // uncomment to debug this hook
+            bool _debug_damage_and_healing = (unit && unit->GetTypeId() == TYPEID_PLAYER);
+            
+            // Only if this aura has a duration
+            if (aura->GetDuration() > 0 || aura->GetMaxDuration() > 0)
             {
-                LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::OnAuraApply(): Spell '{}' had it's duration adjusted ({}->{}).", aura->GetSpellInfo()->SpellName[0], aura->GetMaxDuration()/1000, auraDuration/1000);
-                aura->SetMaxDuration(auraDuration);
-                aura->SetDuration(auraDuration);
+                uint32 auraDuration = _Modifier_CCDuration(unit, aura->GetCaster(), aura);
+
+                // only update if we decided to change it
+                if (auraDuration != (float)aura->GetDuration())
+                {
+                    if (_debug_damage_and_healing) LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::OnAuraApply(): Spell '{}' had it's duration adjusted ({}->{}).", aura->GetSpellInfo()->SpellName[0], aura->GetMaxDuration()/1000, auraDuration/1000);
+                    
+                    aura->SetMaxDuration(auraDuration);
+                    aura->SetDuration(auraDuration);
+                }
             }
         }
-    }
 
-    uint32 _Modify_Damage_Healing(Unit* target, Unit* source, int32 value)
-    {
-        //
-        // Pre-flight Checks
-        //
+    private:
+        bool _debug_damage_and_healing = false; // defaults to false, overwritten in each function
 
-        bool debug = (source && target && (source->GetTypeId() == TYPEID_PLAYER || target->GetTypeId() == TYPEID_PLAYER));
+        void _Debug_Output(std::string function_name, Unit* target, Unit* source, int32 amount, std::string prefix = "", std::string spell_name = "Unknown Spell", uint32 spell_id = 0)
+        {
+            if (target && source && amount)
+            {
+                LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::{}(): {} {} {} {} ({} - {})", function_name, prefix, source->GetName(), amount, target->GetName(), spell_name, spell_id);
+            }
+            else if (target && source)
+            {
+                LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::{}(): {} {} 0 {} ({} - {})", function_name, prefix, source->GetName(), target->GetName(), spell_name, spell_id);
+            }
+            else if (target && amount)
+            {
+                LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::{}(): {} ?? {} {} ({} - {})", function_name, prefix, amount, target->GetName(), spell_name, spell_id);
+            } 
+            else if (target)
+            {
+                LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::{}(): {} ?? ?? {} ({} - {})", function_name, prefix, target->GetName(), spell_name, spell_id);
+            } 
+            else
+            {
+                LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::{}(): {} W? T? F? ({} - {})", function_name, prefix, spell_name, spell_id);
+            }
+        }
 
-        // make sure the source and target are in an instance, else return the original damage
-        if (
-            !(
-                (source->GetMap()->IsDungeon() && target->GetMap()->IsDungeon()) ||
-                (source->GetMap()->IsBattleground() && target->GetMap()->IsBattleground())
+        int32 _Modify_Damage_Healing(Unit* target, Unit* source, int32 amount)
+        {
+            //
+            // Pre-flight Checks
+            //
+
+            // uncomment to debug this function
+            bool _debug_damage_and_healing = ((source && source->GetTypeId() == TYPEID_PLAYER) || (target && target->GetTypeId() == TYPEID_PLAYER));
+
+            // check that we're enabled globally, else return the original value
+            if (!EnableGlobal)
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): EnableGlobal is false, returning original value of {}.", amount);
+
+                return amount;
+            }
+
+            // if the source is gone (logged off? despawned?), use the same target and source
+            // hacky, but better than crashing or having the damage go to 1.0x
+            if (!source)
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is null, using target as source.");
+
+                source = target;
+            }
+
+            // make sure the source and target are in an instance, else return the original damage
+            if (
+                !(
+                    (source->GetMap()->IsDungeon() && target->GetMap()->IsDungeon()) ||
+                    (source->GetMap()->IsBattleground() && target->GetMap()->IsBattleground())
+                )
             )
-           )
-        {
-            if (debug) LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Not in an instance, returning original value.");
-            return value;
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Not in an instance, returning original value of {}.", amount);
+
+                return amount;
+            }
+
+            // make sure we have a source and that the source is in the world, else return the original value
+            if (!source || !source->IsInWorld())
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source does not exist in the world, returning original value of {}.", amount);
+
+                return amount;
+            }
+
+            // get the map's info to see if we're enabled
+            AutoBalanceMapInfo *sourceMapInfo = source->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+            AutoBalanceMapInfo *targetMapInfo = target->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+
+            // if either the target or the attacker's maps are not enabled, return the original damage
+            if (!sourceMapInfo->enabled || !targetMapInfo->enabled)
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source or Target's map is not enabled, returning original value of {}.", amount);
+
+                return amount;
+            }
+
+            //
+            // Source and Target Checking
+            //
+
+            // if the source is a player and they are healing themselves, return the original value
+            if (source->GetTypeId() == TYPEID_PLAYER && source->GetGUID() == target->GetGUID() && amount >= 0)
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a player that is self-healing, returning original value of {}.", amount);
+
+                return amount;
+            }
+            // if the source is a player and they are damaging themselves, log to debug but continue
+            else if (source->GetTypeId() == TYPEID_PLAYER && source->GetGUID() == target->GetGUID() && amount < 0)
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a player that is self-damaging, continuing.");
+            }
+            // if the source is a player and they are damaging unit that is friendly, log to debug but continue
+            else if (source->GetTypeId() == TYPEID_PLAYER && target->IsFriendlyTo(source) && amount < 0)
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a player that is damaging a friendly unit, continuing.");
+            }
+            // if the source is a player under any other condition, return the original value
+            else if (source->GetTypeId() == TYPEID_PLAYER)
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a player, returning original value of {}.", amount);
+
+                return amount;
+            }
+
+            // if the source is under the control of the player, return the original damage
+            // noteably, this should NOT include mind control targets
+            if ((source->IsHunterPet() || source->IsPet() || source->IsSummon()) && source->IsControlledByPlayer())
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a pet or summon, returning original value of {}.", amount);
+
+                return amount;
+            }
+
+            //
+            // Multiplier calculation
+            //
+            float damageMultiplier = 1.0f;
+
+            // if the source is a player AND the target is that same player AND the value is damage (negative), use the map's multiplier
+            if (source->GetTypeId() == TYPEID_PLAYER && source->GetGUID() == target->GetGUID() && amount < 0)
+            {
+                damageMultiplier = sourceMapInfo->worldDamageHealingMultiplier;
+                if (_debug_damage_and_healing)
+                {
+                    LOG_DEBUG("module.AutoBalance.Damage",
+                              "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a player and the target is that same player, using the map's multiplier: {}",
+                              damageMultiplier
+                    );
+                }
+            }
+            // if the target is a player AND the value is healing (positive), use the map's damage multiplier
+            else if (target->GetTypeId() == TYPEID_PLAYER && amount >= 0)
+            {
+                damageMultiplier = targetMapInfo->worldDamageHealingMultiplier;
+                if (_debug_damage_and_healing)
+                {
+                    LOG_DEBUG("module.AutoBalance.Damage",
+                              "AutoBalance_UnitScript::_Modify_Damage_Healing(): Target for healing is a player, using the map's multiplier: {}",
+                              damageMultiplier
+                    );
+                }
+            }
+            // if the target is a player AND the source is not a creature, use the map's multiplier
+            else if (target->GetTypeId() == TYPEID_PLAYER && source->GetTypeId() != TYPEID_UNIT && amount < 0)
+            {
+                damageMultiplier = targetMapInfo->worldDamageHealingMultiplier;
+                if (_debug_damage_and_healing)
+                {
+                    LOG_DEBUG("module.AutoBalance.Damage",
+                              "AutoBalance_UnitScript::_Modify_Damage_Healing(): Target is a player and the source is not a creature, using the map's damage multiplier: {}",
+                              damageMultiplier
+                    );
+                }
+            }
+            // otherwise, use the source creature's damage multiplier
+            else
+            {
+                damageMultiplier = source->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->DamageMultiplier;
+                if (_debug_damage_and_healing)
+                {
+                    LOG_DEBUG("module.AutoBalance.Damage",
+                              "AutoBalance_UnitScript::_Modify_Damage_Healing(): Using the source creature's damage multiplier: {}",
+                              damageMultiplier
+                    );
+                }
+            }
+
+            // we are good to go, return the original damage times the multiplier
+            if (_debug_damage_and_healing)
+                LOG_DEBUG("module.AutoBalance.Damage", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Returning modified damage: {} * {} = {}", amount, damageMultiplier, amount * damageMultiplier);
+
+            return amount * damageMultiplier;
         }
 
-        // check that we're enabled globally, else return the original value
-        if (!EnableGlobal)
+        uint32 _Modifier_CCDuration(Unit* target, Unit* caster, Aura* aura)
         {
-            if (debug) LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): EnableGlobal is false, returning original value.");
-            return value;
-        }
+            // store the original duration of the aura
+            float originalDuration = (float)aura->GetDuration();
 
-        // make sure we have a source and that the source is in the world, else return the original value
-        if (!source || !source->IsInWorld())
-        {
-            if (debug) LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source does not exist in the world, returning original value.");
-            return value;
-        }
+            // check that we're enabled globally, else return the original duration
+            if (!EnableGlobal)
+                return originalDuration;
 
-        // get the map's info to see if we're enabled
-        AutoBalanceMapInfo *sourceMapInfo = source->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
-        AutoBalanceMapInfo *targetMapInfo = target->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+            // ensure that both the target and the caster are defined
+            if (!target || !caster)
+                return originalDuration;
 
-        // if either the target or the attacker's maps are not enabled, return the original damage
-        if (!sourceMapInfo->enabled || !targetMapInfo->enabled)
-        {
-            if (debug) LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source or Target's map is not enabled, returning original value.");
-            return value;
-        }
+            // if the aura wasn't cast just now, don't change it
+            if (aura->GetDuration() != aura->GetMaxDuration())
+                return originalDuration;
 
-        //
-        // Source and Target Checking
-        //
+            // if the target isn't a player or the caster is a player, return the original duration
+            if (!target->IsPlayer() || caster->IsPlayer())
+                return originalDuration;
 
-        // if the source is a player and they are healing themselves, return the original value
-        if (source->GetTypeId() == TYPEID_PLAYER && source->GetGUID() == target->GetGUID() && value >= 0)
-        {
-            if (debug) LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a player that is self-healing, returning original value.");
-            return value;
-        }
-        // if the source is a player and they are damaging themselves, log to debug but continue
-        else if (source->GetTypeId() == TYPEID_PLAYER && source->GetGUID() == target->GetGUID() && value < 0)
-        {
-            if (debug) LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a player that is self-damaging, continuing.");
-        }
-        // if the source is a player and they are damaging unit that is friendly, log to debug but continue
-        else if (source->GetTypeId() == TYPEID_PLAYER && target->IsFriendlyTo(source) && value < 0)
-        {
-            if (debug) LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a player that is damaging a friendly unit, continuing.");
-        }
-        // if the source is a player under any other condition, return the original value
-        else if (source->GetTypeId() == TYPEID_PLAYER)
-        {
-            if (debug) LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a player, returning original value.");
-            return value;
-        }
-
-        // if the source is under the control of the player, return the original damage
-        if ((source->IsHunterPet() || source->IsPet() || source->IsSummon()) && source->IsControlledByPlayer())
-        {
-            if (debug) LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a pet or summon, returning original value.");
-            return value;
-        }
-
-        //
-        // Multiplier calculation
-        //
-        float damageMultiplier = 1.0f;
-
-        // if the source is a player AND the target is that same player AND the value is damage (negative), use the map's multiplier
-        if (source->GetTypeId() == TYPEID_PLAYER && source->GetGUID() == target->GetGUID() && value < 0)
-        {
-            damageMultiplier = sourceMapInfo->worldDamageHealingMultiplier;
-            if (debug) LOG_DEBUG("module.AutoBalance",
-                "AutoBalance_UnitScript::_Modify_Damage_Healing(): Source is a player and the target is that same player, using the map's multiplier: {}",
-                damageMultiplier
-            );
-        }
-        // if the target is a player AND the value is healing (positive), use the map's damage multiplier
-        else if (target->GetTypeId() == TYPEID_PLAYER && value >= 0)
-        {
-            damageMultiplier = targetMapInfo->worldDamageHealingMultiplier;
-            if (debug) LOG_DEBUG("module.AutoBalance",
-                "AutoBalance_UnitScript::_Modify_Damage_Healing(): Target for healing is a player, using the map's multiplier: {}",
-                damageMultiplier
-            );
-        }
-        // if the target is a player AND the source is not a creature, use the map's multiplier
-        else if (target->GetTypeId() == TYPEID_PLAYER && source->GetTypeId() != TYPEID_UNIT && value < 0)
-        {
-            damageMultiplier = targetMapInfo->worldDamageHealingMultiplier;
-            if (debug) LOG_DEBUG("module.AutoBalance",
-                "AutoBalance_UnitScript::_Modify_Damage_Healing(): Target is a player and the source is not a creature, using the map's damage multiplier: {}",
-                damageMultiplier
-            );
-        }
-        // otherwise, use the source creature's damage multiplier
-        else
-        {
-            damageMultiplier = source->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->DamageMultiplier;
-            if (debug) LOG_DEBUG("module.AutoBalance",
-                "AutoBalance_UnitScript::_Modify_Damage_Healing(): Using the source creature's damage multiplier: {}",
-                damageMultiplier
-            );
-        }
-
-        // we are good to go, return the original damage times the multiplier
-        if (debug) LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): Returning modified damage: {} * {} = {}", value, damageMultiplier, value * damageMultiplier);
-        return value * damageMultiplier;
-    }
-
-    uint32 _Modifier_CCDuration(Unit* target, Unit* caster, Aura* aura)
-    {
-        // store the original duration of the aura
-        float originalDuration = (float)aura->GetDuration();
-
-        // check that we're enabled globally, else return the original duration
-        if (!EnableGlobal)
-            return originalDuration;
-
-        // ensure that both the target and the caster are defined
-        if (!target || !caster)
-            return originalDuration;
-
-        // if the aura wasn't cast just now, don't change it
-        if (aura->GetDuration() != aura->GetMaxDuration())
-            return originalDuration;
-
-        // if the target isn't a player or the caster is a player, return the original duration
-        if (!target->IsPlayer() || caster->IsPlayer())
-            return originalDuration;
-
-        // make sure we're in an instance, else return the original duration
-        if (
-            !(
-                (target->GetMap()->IsDungeon() && caster->GetMap()->IsDungeon()) ||
-                (target->GetMap()->IsBattleground() && caster->GetMap()->IsBattleground())
+            // make sure we're in an instance, else return the original duration
+            if (
+                !(
+                    (target->GetMap()->IsDungeon() && caster->GetMap()->IsDungeon()) ||
+                    (target->GetMap()->IsBattleground() && caster->GetMap()->IsBattleground())
+                )
             )
-           )
-            return originalDuration;
+                return originalDuration;
 
-        // get the current creature's CC duration multiplier
-        float ccDurationMultiplier = caster->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->CCDurationMultiplier;
+            // get the current creature's CC duration multiplier
+            float ccDurationMultiplier = caster->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo")->CCDurationMultiplier;
 
-        // if it's the default of 1.0, return the original damage
-        if (ccDurationMultiplier == 1)
-            return originalDuration;
+            // if it's the default of 1.0, return the original damage
+            if (ccDurationMultiplier == 1)
+                return originalDuration;
 
-        // if the aura was cast by a pet or summon, return the original duration
-        if ((caster->IsHunterPet() || caster->IsPet() || caster->IsSummon()) && caster->IsControlledByPlayer())
-            return originalDuration;
+            // if the aura was cast by a pet or summon, return the original duration
+            if ((caster->IsHunterPet() || caster->IsPet() || caster->IsSummon()) && caster->IsControlledByPlayer())
+                return originalDuration;
 
-        // only if this aura is a CC
-        if (
-            aura->HasEffectType(SPELL_AURA_MOD_CHARM)          ||
-            aura->HasEffectType(SPELL_AURA_MOD_CONFUSE)        ||
-            aura->HasEffectType(SPELL_AURA_MOD_DISARM)         ||
-            aura->HasEffectType(SPELL_AURA_MOD_FEAR)           ||
-            aura->HasEffectType(SPELL_AURA_MOD_PACIFY)         ||
-            aura->HasEffectType(SPELL_AURA_MOD_POSSESS)        ||
-            aura->HasEffectType(SPELL_AURA_MOD_SILENCE)        ||
-            aura->HasEffectType(SPELL_AURA_MOD_STUN)           ||
-            aura->HasEffectType(SPELL_AURA_MOD_SPEED_SLOW_ALL)
-            )
-        {
-            return originalDuration * ccDurationMultiplier;
-        }
-        else
-        {
-            return originalDuration;
-        }
+            // only if this aura is a CC
+            if (
+                aura->HasEffectType(SPELL_AURA_MOD_CHARM)          ||
+                aura->HasEffectType(SPELL_AURA_MOD_CONFUSE)        ||
+                aura->HasEffectType(SPELL_AURA_MOD_DISARM)         ||
+                aura->HasEffectType(SPELL_AURA_MOD_FEAR)           ||
+                aura->HasEffectType(SPELL_AURA_MOD_PACIFY)         ||
+                aura->HasEffectType(SPELL_AURA_MOD_POSSESS)        ||
+                aura->HasEffectType(SPELL_AURA_MOD_SILENCE)        ||
+                aura->HasEffectType(SPELL_AURA_MOD_STUN)           ||
+                aura->HasEffectType(SPELL_AURA_MOD_SPEED_SLOW_ALL)
+                )
+            {
+                return originalDuration * ccDurationMultiplier;
+            }
+            else
+            {
+                return originalDuration;
+            }
     }
 };
 
@@ -2724,10 +2780,62 @@ class AutoBalance_GameObjectScript : public AllGameObjectScript
         : AllGameObjectScript("AutoBalance_GameObjectScript")
         {}
 
-        void OnGameObjectModifyHealth(GameObject* go, Unit* attackerOrHealer, int32& change, SpellInfo const* spellInfo) override
+        void OnGameObjectModifyHealth(GameObject* target, Unit* source, int32& amount, SpellInfo const* spellInfo) override
         {
+            bool _debug_damage_and_healing = (source && target && (source->GetTypeId() == TYPEID_PLAYER || source->IsControlledByPlayer()));
+            if (_debug_damage_and_healing)
+                LOG_DEBUG("module.AutoBalance", "AutoBalance_GameObjectScript::OnGameObjectModifyHealth(): BEFORE: {} {} {} ({})", source->GetName(), amount, target->GetName(), spellInfo->SpellName[0]);
+
+            amount = _Modify_GameObject_Damage_Healing(target, source, amount);
+
+            if (_debug_damage_and_healing)
+                LOG_DEBUG("module.AutoBalance", "AutoBalance_GameObjectScript::OnGameObjectModifyHealth(): AFTER: {} {} {} ({})", source->GetName(), amount, target->GetName(), spellInfo->SpellName[0]);
+        }
+
+    private:
+
+        bool _debug_damage_and_healing = false; // defaults to false, overwritten in each function
+
+        int32 _Modify_GameObject_Damage_Healing(GameObject* target, Unit* source, int32 amount)
+        {
+            //
+            // Pre-flight Checks
+            //
+
+            // bool _debug_damage_and_healing = (source && target && (source->GetTypeId() == TYPEID_PLAYER || target->GetTypeId() == TYPEID_PLAYER));
+
+            // check that we're enabled globally, else return the original value
+            if (!EnableGlobal)
+            {
+                if (_debug_damage_and_healing)
+                    LOG_DEBUG("module.AutoBalance", "AutoBalance_UnitScript::_Modify_Damage_Healing(): EnableGlobal is false, returning original value.");
+
+                return amount;
+            }
+
+            // if the source is gone (logged off? despawned?), use the map's multipliers as a fallback
+            // short-circuit returned here to keep from null calls later on
+            if (!source)
+            {
+                return amount;
+            }
+
+            return amount;
 
         }
+
+        int32 _Calculate_Amount_For_GameObject (GameObject* target, int32 amount)
+        {
+            // get the map's info
+            AutoBalanceMapInfo *targetMapInfo = target->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+            float healthMultiplier = targetMapInfo->worldDamageHealingMultiplier;
+
+            uint32 origMaxHealth = target->GetGOValue()->Building.MaxHealth;
+
+
+        }
+
+
 };
 
 

--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -4358,15 +4358,36 @@ class AutoBalance_AllMapScript : public AllMapScript
                     mapABInfo->lfgMinLevel = dungeon->MinLevel;
                     mapABInfo->lfgMaxLevel = dungeon->MaxLevel;
                     mapABInfo->lfgTargetLevel = dungeon->TargetLevel;
+                }
+                // if this is a heroic dungeon that isn't in LFG, get the stats from the non-heroic version
+                else if (map->IsHeroic())
+                {
+                    LFGDungeonEntry const* nonHeroicDungeon = nullptr;
+                    if (map->GetDifficulty() == DUNGEON_DIFFICULTY_HEROIC)
+                    {
+                        nonHeroicDungeon = GetLFGDungeon(map->GetId(), DUNGEON_DIFFICULTY_HEROIC);
+                    }
+                    else if (map->GetDifficulty() == RAID_DIFFICULTY_10MAN_HEROIC)
+                    {
+                        nonHeroicDungeon = GetLFGDungeon(map->GetId(), RAID_DIFFICULTY_10MAN_NORMAL);
+                    }
+                    else if (map->GetDifficulty() == RAID_DIFFICULTY_25MAN_HEROIC)
+                    {
+                        nonHeroicDungeon = GetLFGDungeon(map->GetId(), RAID_DIFFICULTY_25MAN_NORMAL);
+                    }
 
-                    LOG_DEBUG("module.AutoBalance", "AutoBalance_AllMapScript::OnCreateMap(): Map {} ({}{}) | LFG Min: {} Max: {} Target: {}",
+                    LOG_DEBUG("module.AutoBalance", "AutoBalance_AllMapScript::OnCreateMap(): Map {} ({}{}) | is a Heroic dungeon that is not in LFG. Using non-heroic LFG levels.",
                         map->GetMapName(),
                         map->GetId(),
-                        map->GetInstanceId() ? "-" + std::to_string(map->GetInstanceId()) : "",
-                        mapABInfo->lfgMinLevel,
-                        mapABInfo->lfgMaxLevel,
-                        mapABInfo->lfgTargetLevel
+                        map->GetInstanceId() ? "-" + std::to_string(map->GetInstanceId()) : ""
                     );
+
+                    if (nonHeroicDungeon)
+                    {
+                        mapABInfo->lfgMinLevel = nonHeroicDungeon->MinLevel;
+                        mapABInfo->lfgMaxLevel = nonHeroicDungeon->MaxLevel;
+                        mapABInfo->lfgTargetLevel = nonHeroicDungeon->TargetLevel;
+                    }
                 }
 
                 if (map->GetInstanceId())


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This is a fairly major rewrite of large parts of AutoBalance. While the user-facing side of things (the .conf file) is hardly changed at all, the internals behind it are quite different.

**Observable changes**
- Handle damage and healing that doesn't come from a creature (world damage, self-damage, NPC healing, etc)
- Destructible buildings have the damage done to them scaled appropriately based on the scaling settings
- More reliable boss and boss summon detection - both get treated as bosses for multipliers
- Rewrite of in-combat locking for players leaving the instance during combat - if any player in the instance is in combat, the difficulty only goes UP until combat ends
- Reduce "level up animation" events on creatures by setting their level before they're spawned into the world
- Improved player notifications when entering/exiting dungeons
- Add commands and logger info to `README.md`, update the GitHub bug template

**Less-obvious changes**
- Complete rewrite of the level/player scaling process, separating many pieces of repeated code into functions
- Improved handling of GMs entering/exiting the instance
- Handle debuffs that do "X% of player health" damage correctly - do not level scale
- Performance improvements, with fewer unneeded checks being performed
- Fewer incorrectly-scaled creatures (flavor critters, player summons, friendly NPCs, other irrelevant creatures)
- Improved `.ab mapstat` and `.ab creaturestat` output
- Many many many many debug logs added or changed, including the start of splitting the logs into different logging sinks. Detailed multiplier calculation logs, damage adjustment logs, combat locking logs.
- Many settings are now stored in the map data itself, paving the way for map-specific settings in the future

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #148 
- Closes #142
- Closes #40 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
N/A

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested on latest AC with four people doing multiple dungeons and raids

## Known Issues and TODO List
- disabled for Battlegrounds entirely. It already wasn't working correctly and was causing crashes in some cases (#148). I have it in my backlog to try to re-add it eventually.
- disabled `LevelScaling.EndGameBoost` which is currently WAAAAY overtuned (#156). I need to figure out how the original developers of the module came up with the multipliers they did, and if they are still needed given how I'm generating multipliers now.
- #158 

I'm tempted to work on these before submitting this PR but... do you really want this to be any larger?

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Use AutoBalance as normal. The user-facing changes should be minimal. However, there will likely be encounters that were previously scaled incorrectly and may now be possible.
