### PR TITLE
Solved a bug which caused part of the creature to not be properly sca…

### DIFF
--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -4599,7 +4599,7 @@ class AutoBalance_AllMapScript : public AllMapScript
             LocaleConstant locale = session->GetSessionDbLocaleIndex();
 
             // if the previous player count is the same as the new player count, update without force
-            if (prevAdjustedPlayerCount == mapABInfo->adjustedPlayerCount)
+            if ((prevAdjustedPlayerCount == mapABInfo->adjustedPlayerCount) && (mapABInfo->adjustedPlayerCount != 1))
             {
                 LOG_DEBUG("module.AutoBalance", "AutoBalance_AllMapScript::OnPlayerEnterAll: Player difficulty unchanged at {}. Updating map data (no force).",
                     mapABInfo->adjustedPlayerCount


### PR DESCRIPTION
…led in case the group in the instance is formed by only one character, since the number of players before and after is always one

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Forced map reset for instance groups different than one. In case of a single player, the condition
`if (prevAdjustedPlayerCount == mapABInfo->adjustedPlayerCount)` is always true, since it will be solved as 1 = 1.
This cause an **unforced** map update, that results in a missing update of already scaled creatures using the LFG average level. For low level instances this means that part of the mobs will be present at a lower/higher level than the desired one.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes issue #176

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- See the issue for a trace of the testing performed in order to detect the malfunctioning part.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Build without error
- Tested in `Linux WOWSERVER 5.15.153.1-microsoft-standard-WSL2 #1 SMP Fri Mar 29 23:14:13 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux` with Ubuntu 22.04

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Compile the module with the master branch
2. Enter a low level instance (Wailing Caverns) with a high level character (50+); part of the initial mobs will be around level 19. Enter manually, do not use LFG or similar tools.
3. Compile the module with the fix and repeat after exiting and resetting the instance. The mobs and NPC at the start will be around the requested level.

**BONUS:** See the issue #176 to compile with log messages that allows tracing the issue
